### PR TITLE
Audio fix

### DIFF
--- a/src/matoya.h
+++ b/src/matoya.h
@@ -1324,7 +1324,8 @@ MTY_AudioGetQueued(MTY_Audio *ctx);
 ///   case, one audio frame is two samples, each sample being one channel.
 /// @param count The number of frames contained in `frames`. The number of frames would
 ///   be the size of `frames` in bytes divided by 4.
-MTY_EXPORT void
+/// @returns On failure, an error code is returned. Otherwise, returns 0.
+MTY_EXPORT uint32_t
 MTY_AudioQueue(MTY_Audio *ctx, const int16_t *frames, uint32_t count);
 
 

--- a/src/unix/linux/android/audio.c
+++ b/src/unix/linux/android/audio.c
@@ -28,10 +28,14 @@ struct MTY_Audio {
 
 	uint8_t *buffer;
 	size_t size;
+	uint32_t ret;
 };
 
 static void audio_error(AAudioStream *stream, void *userData, aaudio_result_t error)
 {
+	MTY_Audio *ctx = userData;
+	ctx->ret = error;
+
 	MTY_Log("'AAudioStream' error %d", error);
 }
 
@@ -135,10 +139,12 @@ static void audio_start(MTY_Audio *ctx)
 	}
 }
 
-void MTY_AudioQueue(MTY_Audio *ctx, const int16_t *frames, uint32_t count)
+uint32_t MTY_AudioQueue(MTY_Audio *ctx, const int16_t *frames, uint32_t count)
 {
 	size_t data_size = count * AUDIO_CHANNELS * 2;
 
+	ctx->ret = 0;
+	
 	audio_start(ctx);
 
 	MTY_MutexLock(ctx->mutex);
@@ -160,4 +166,5 @@ void MTY_AudioQueue(MTY_Audio *ctx, const int16_t *frames, uint32_t count)
 		ctx->playing = true;
 
 	MTY_MutexUnlock(ctx->mutex);
+	return ctx->ret;
 }


### PR DESCRIPTION
Fixes #37

Makes MTY_AudioQueue return the return value of the last function called within it.
Where applicable, returns error callback values.