### PR TITLE
Update matoya.js

### DIFF
--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -1274,13 +1274,14 @@ const MTY_WASI_API = {
 
 			let ptr = iovs;
 			let cbuf = MTY_GetUint32(ptr);
-			let cbuf_len = MTY_GetUint32(ptr + 4);
+			let cbuf_len = MTY_GetUint32(ptr + 4) + 1;
 			let len = cbuf_len < full_buf.length ? cbuf_len : full_buf.length;
 
 			let view = new Uint8Array(mty_mem(), cbuf, cbuf_len);
 			let slice = new Uint8Array(full_buf.buffer, 0, len);
 			view.set(slice);
 
+			MTY_SetUint32(ptr + 4, len + 1);
 			MTY_SetUint32(nread, len);
 
 			return 0; //OK

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -1263,9 +1263,11 @@ const MTY_WASI_API = {
 			view.set(slice);
 
 			MTY_SetUint32(nread, len);
+
+			return 0; //OK
 		}
 
-		return 0;
+		return 2; //ENOENT
 	},
 	fd_write: function (fd, iovs, iovs_len, nwritten) {
 		// Calculate full write size

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -1201,6 +1201,9 @@ const MTY_WASI_API = {
 			const buf = mty_b64_to_buf(localStorage[path]);
 			MTY_SetUint64(filestat_out + 32, buf.byteLength);
 		}
+		else {
+			MTY_SetUint64(filestat_out + 32, 0);
+		}
 
 		return 0;
 	},

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -1241,11 +1241,22 @@ const MTY_WASI_API = {
 	},
 	fd_fdstat_set_flags: function () {
 	},
+	fd_filestat_set_size: function (fd, size) {
+	},
 	fd_readdir: function () {
 		return 8;
 	},
 	fd_seek: function (fd, offset, whence, offset_out) {
 		return 0;
+	},
+	fd_tell: function (fd) {
+		const finfo = MTY.fds[fd];
+
+		if (finfo && localStorage[finfo.path]) {
+			return mty_b64_to_buf(localStorage[finfo.path]).length;
+		}
+		
+		reutrn -1;
 	},
 	fd_read: function (fd, iovs, iovs_len, nread) {
 		const finfo = MTY.fds[fd];
@@ -1324,6 +1335,11 @@ const MTY_WASI_API = {
 		return 0;
 	},
 	proc_exit: function () {
+	},
+	environ_get: function(environ, environ_buf) {
+	},
+	environ_sizes_get: function() {
+		return 0;
 	},
 };
 

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -118,9 +118,7 @@ function MTY_SetFloat(ptr, value) {
 }
 
 function MTY_SetUint64(ptr, value) {
-	const mem_view = mty_mem_view();
-	mem_view.setUint32(ptr + 0, value % 0x100000000, true);
-    mem_view.setUint32(ptr + 4, value / 0x100000000, true);
+	mty_mem_view().setBigUint64(ptr, BigInt(value), true);
 }
 
 function MTY_GetUint32(ptr) {
@@ -284,7 +282,7 @@ const MTY_GL_API = {
 			mty_gl_get_texture(type, data));
 	},
 	glTexSubImage2D: function (target, level, xoffset, yoffset, width, height, format, type, pixels) {
-		MTY.gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, 
+		MTY.gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type,
 			mty_gl_get_texture(type, pixels));
 	},
 	glDrawElements: function (mode, count, type, indices) {
@@ -729,7 +727,7 @@ function mty_poll_gamepads(app, controller) {
 
 	//Some browsers completely disable the function on non-secure contexts
 	if (!navigator.getGamepads)
-		return; 
+		return;
 
 	const gps = navigator.getGamepads();
 
@@ -1205,8 +1203,7 @@ const MTY_WASI_API = {
 			// We only need to return the size
 			const buf = mty_b64_to_buf(localStorage[path]);
 			MTY_SetUint64(filestat_out + 32, buf.byteLength);
-		}
-		else {
+		} else {
 			MTY_SetUint64(filestat_out + 32, 0);
 		}
 
@@ -1263,8 +1260,8 @@ const MTY_WASI_API = {
 		if (finfo && localStorage[finfo.path]) {
 			return mty_b64_to_buf(localStorage[finfo.path]).length;
 		}
-		
-		reutrn -1;
+
+		return -1;
 	},
 	fd_read: function (fd, iovs, iovs_len, nread) {
 		const finfo = MTY.fds[fd];
@@ -1348,7 +1345,7 @@ const MTY_WASI_API = {
 			time = performance.now()
 
 		MTY_SetUint64(time_out, Math.round(time * 1000.0 * 1000.0));
-		
+
 		return 0;
 	},
 	poll_oneoff: function (sin, sout, nsubscriptions, nevents) {

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -726,6 +726,11 @@ function mty_correct_relative() {
 }
 
 function mty_poll_gamepads(app, controller) {
+
+	//Some browsers completely disable the function on non-secure contexts
+	if (!navigator.getGamepads)
+		return; 
+
 	const gps = navigator.getGamepads();
 
 	for (let x = 0; x < 4; x++) {

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -118,7 +118,9 @@ function MTY_SetFloat(ptr, value) {
 }
 
 function MTY_SetUint64(ptr, value) {
-	mty_mem_view().setBigUint64(ptr, BigInt(value), true);
+	const mem_view = mty_mem_view();
+	mem_view.setUint32(ptr + 0, value % 0x100000000, true);
+    mem_view.setUint32(ptr + 4, value / 0x100000000, true);
 }
 
 function MTY_GetUint32(ptr) {

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -181,6 +181,14 @@ function mty_gl_obj(index) {
 	return MTY.glObj[index];
 }
 
+function mty_gl_get_texture(type, data) {
+	if (type == MTY.gl.UNSIGNED_BYTE)
+		return new Uint8Array(mty_mem(), data);
+	if (type == MTY.gl.FLOAT)
+		return new Float32Array(mty_mem(), data);
+	return new Uint16Array(mty_mem(), data);
+}
+
 const MTY_GL_API = {
 	glGenFramebuffers: function (n, ids) {
 		for (let x = 0; x < n; x++)
@@ -271,11 +279,11 @@ const MTY_GL_API = {
 	},
 	glTexImage2D: function (target, level, internalformat, width, height, border, format, type, data) {
 		MTY.gl.texImage2D(target, level, internalformat, width, height, border, format, type,
-			new Uint8Array(mty_mem(), data));
+			mty_gl_get_texture(type, data));
 	},
 	glTexSubImage2D: function (target, level, xoffset, yoffset, width, height, format, type, pixels) {
-		MTY.gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type,
-			new Uint8Array(mty_mem(), pixels));
+		MTY.gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, 
+			mty_gl_get_texture(type, pixels));
 	},
 	glDrawElements: function (mode, count, type, indices) {
 		MTY.gl.drawElements(mode, count, type, indices);

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -1336,7 +1336,18 @@ const MTY_WASI_API = {
 
 	// Misc
 	clock_time_get: function (id, precision, time_out) {
-		MTY_SetUint64(time_out, Math.round(performance.now() * 1000.0 * 1000.0));
+		let time = 0;
+
+		// CLOCK_REALTIME
+		if (id == 0)
+			time = Date.now();
+
+		// CLOCK_MONOTONIC
+		if (id == 1)
+			time = performance.now()
+
+		MTY_SetUint64(time_out, Math.round(time * 1000.0 * 1000.0));
+		
 		return 0;
 	},
 	poll_oneoff: function (sin, sout, nsubscriptions, nevents) {


### PR DESCRIPTION
Hello :slightly_smiling_face: Some updates on `matoya.js`:
* Create javascript arrays based on the pixel size. Chrome and Firefox are complaining about `Uint8Array` if the pixel size does not match the type of array. Creation priority has been deduced from [the MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D).
* `setUint32` helps in some versions of Safari that does not provide support for setBigUint64. Using setUint32 twice instead improves compatibility on this browser. EDIT: reverted as this is now supported in Safari 15.
* `fd_read` was always returning 0, which means for the WASM code that the file exists, even if not. This causes inifite loops (and eventually out-of-bounds memory errors). Now, if no file descriptor has been registered or if the file does not exists, ENOENT is returned.
* [`environ_get`](https://docs.rs/wasi/0.10.2+wasi-snapshot-preview1/wasi/fn.environ_get.html), [`environ_sizes_get`](https://docs.rs/wasi/0.10.2+wasi-snapshot-preview1/wasi/fn.environ_sizes_get.html), [`fd_tell`](https://docs.rs/wasi/0.10.2+wasi-snapshot-preview1/wasi/fn.fd_tell.html) and [`fd_filestat_set_size`](https://docs.rs/wasi/0.10.2+wasi-snapshot-preview1/wasi/fn.fd_filestat_set_size.html) has been added to the JS-implemented WASI api. Not sure if those are required in all situations (it was for me), but I believe having them anyway is not harmful.
* Make `path_filestat_get` return an empty size when file is not found in storage. If `filestat_out` is passed to the function unintialized, the value was not overwritten and was sometimes used as-is in the underlying application (happened to me when porting a libretro core).
* Check if `navigator.getGamepads` is available before using it. Some browsers might completely disable the function on non-secure contexts (e.g. Firefox). This check prevents the whole application to crash if there's no gamepad API available.
* Add support for `CLOCK_REALTIME` in `clock_get_time`. This allows the `time(NULL)` call (among others) to return the correct Unix timestamp.
* Make `fd_read` report the correct amount of bytes. I ran into a curious issue: when reading a file, the last byte was set to value value of the first one. The reason seems to come from `__stdio_read` in wasi-libc, which is consireing all buffers as strings (i.e. skipping the last byte). A workaround to make it work with libmatoya is to patch back `iov_len` with the real expected size.