### PR TITLE
Add ability to build shared libraries

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -63,12 +63,6 @@ FLAGS = \
 	-std=c99 \
 	-fPIC
 
-ifdef DEBUG
-FLAGS := $(FLAGS) -O0 -g
-else
-FLAGS := $(FLAGS) -O3 -g0 -fvisibility=hidden
-endif
-
 ############
 ### WASM ###
 ############
@@ -197,15 +191,28 @@ INCLUDES := $(INCLUDES) -Isrc/unix/apple -Isrc/unix/apple/$(TARGET)
 endif
 endif
 
+ifdef DEBUG
+FLAGS := $(FLAGS) -O0 -g
+else
+DEFS  := $(DEFS) -DMTY_EXPORT='__attribute__((visibility("default")))'
+FLAGS := $(FLAGS) -O3 -g0 -fvisibility=hidden
+endif
+
 CFLAGS = $(INCLUDES) $(DEFS) $(FLAGS)
 OCFLAGS = $(CFLAGS) -fobjc-arc
 
-all: clean-build clear $(SHADERS)
-	make objs -j4
+all: static
 
-objs: $(OBJS)
+prepare: clean-build clear $(SHADERS) $(OBJS)
 	mkdir -p bin/$(TARGET)/$(ARCH)
+
+static: prepare
 	$(AR) -crs bin/$(TARGET)/$(ARCH)/$(NAME).a $(OBJS)
+
+ifeq ($(TARGET), linux)
+shared: prepare
+	$(CC) -shared -o bin/$(TARGET)/$(ARCH)/$(NAME).so $(OBJS)
+endif
 
 ###############
 ### ANDROID ###

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 TARGET = windows
-ARCH = %%Platform%%
+ARCH = $(PROCESSOR_ARCHITECTURE)
 NAME = matoya
 
 .SUFFIXES : .ps4 .vs4 .ps3 .vs3 .vert .frag
@@ -112,6 +112,35 @@ FLAGS = \
 LIB_FLAGS = \
 	/nologo
 
+LIBS = \
+	libvcruntime.lib \
+	libucrt.lib \
+	libcmt.lib \
+	kernel32.lib \
+	windowscodecs.lib \
+	user32.lib \
+	shell32.lib \
+	d3d9.lib \
+	d3d11.lib \
+	dxguid.lib \
+	ole32.lib \
+	uuid.lib \
+	winmm.lib \
+	shcore.lib \
+	bcrypt.lib \
+	userenv.lib \
+	shlwapi.lib \
+	advapi32.lib \
+	opengl32.lib \
+	ws2_32.lib \
+	xinput.lib \
+	gdi32.lib \
+	imm32.lib \
+	winhttp.lib \
+	crypt32.lib \
+	secur32.lib \
+	hid.lib
+
 !IFDEF MTY_NO_WINHTTP
 OBJS = $(OBJS) src\unix\net\request.obj
 !ELSE
@@ -121,14 +150,22 @@ OBJS = $(OBJS) src\windows\net\request.obj
 !IFDEF DEBUG
 FLAGS = $(FLAGS) /Ob0 /Zi
 !ELSE
+DEFS  = $(DEFS) -DMTY_EXPORT=__declspec(dllexport)
 FLAGS = $(FLAGS) /O2 /GS- /Gw
 !ENDIF
 
 CFLAGS = $(INCLUDES) $(DEFS) $(FLAGS)
 
-all: clean-build clear $(SHADERS) $(OBJS)
+all: static
+
+prepare: clean-build clear $(SHADERS) $(OBJS)
 	mkdir bin\$(TARGET)\$(ARCH)
+
+static: prepare
 	lib /out:bin\$(TARGET)\$(ARCH)\$(NAME).lib $(LIB_FLAGS) *.obj
+
+shared: prepare
+	link /dll /out:bin\$(TARGET)\$(ARCH)\$(NAME).dll $(LIB_FLAGS) $(LIBS) *.obj
 
 clean: clean-build
 	@-del /q $(SHADERS) 2>nul


### PR DESCRIPTION
Well, after your suggestion in #25, here is the result. :slightly_smiling_face: 

The proposed flow is as follows:
* `make` has the exact same behavior as before, but is now an alias to `make static`
* `make shared` has been added, outputting an `.so` file on Linux and a `.dll` file on Windows

Side note: how `%%Platform%%` is supposed to be used on Windows? It never resolved to any variable on my side. In this PR, I used `PROCESSOR_ARCHITECTURE` instead, returning either `x86` or `AMD64`, but reverting is always an option!

EDIT: Forgot to mention, I took the list of Windows libraries from [matoya/merton](https://github.com/matoya/merton). Not sure if all of them are required, but I believe so.