### PR TITLE
Draw multiple quads in the same loop iteration

### DIFF
--- a/src/gfx/gl.c
+++ b/src/gfx/gl.c
@@ -277,7 +277,7 @@ bool mty_gl_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	float vpx, vpy, vpw, vph;
-	mty_viewport(desc, true, &vpx, &vpy, &vpw, &vph);
+	mty_viewport(desc, &vpx, &vpy, &vpw, &vph);
 
 	glViewport(lrint(vpx), lrint(vpy) + GL_ORIGIN_Y, lrint(vpw), lrint(vph));
 

--- a/src/gfx/gl.c
+++ b/src/gfx/gl.c
@@ -277,9 +277,7 @@ bool mty_gl_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	float vpx, vpy, vpw, vph;
-	mty_viewport(desc->rotation, desc->cropWidth, desc->cropHeight,
-		desc->viewWidth, desc->viewHeight, desc->aspectRatio, desc->scale,
-		&vpx, &vpy, &vpw, &vph);
+	mty_viewport(desc, true, &vpx, &vpy, &vpw, &vph);
 
 	glViewport(lrint(vpx), lrint(vpy) + GL_ORIGIN_Y, lrint(vpw), lrint(vph));
 
@@ -303,8 +301,10 @@ bool mty_gl_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 	glVertexAttribPointer(ctx->loc_uv,  2, GL_FLOAT, GL_FALSE, 4 * sizeof(GLfloat), (void *) (2 * sizeof(GLfloat)));
 
 	// Clear
-	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-	glClear(GL_COLOR_BUFFER_BIT);
+	if (!desc->layer) {
+		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+		glClear(GL_COLOR_BUFFER_BIT);
+	}
 
 	// Fragment shader
 	for (uint8_t x = 0; x < GL_NUM_STAGING; x++) {

--- a/src/gfx/viewport.h
+++ b/src/gfx/viewport.h
@@ -8,7 +8,7 @@
 
 #include <math.h>
 
-static void mty_viewport(const MTY_RenderDesc *desc, bool bottomOrigin, float *vp_x, float *vp_y, float *vp_w, float *vp_h)
+static void mty_viewport(const MTY_RenderDesc *desc, float *vp_x, float *vp_y, float *vp_w, float *vp_h)
 {
 	float w      = (float)desc->cropWidth;
 	float h      = (float)desc->cropHeight;
@@ -54,9 +54,6 @@ static void mty_viewport(const MTY_RenderDesc *desc, bool bottomOrigin, float *v
 			*vp_y = desc->position.y;
 			break;
 	}
-
-	if (bottomOrigin)
-		*vp_y = view_h - *vp_h - *vp_y;
 
 	*vp_x = roundf(*vp_x);
 	*vp_y = roundf(*vp_y);

--- a/src/gfx/viewport.h
+++ b/src/gfx/viewport.h
@@ -10,14 +10,14 @@
 
 static void mty_viewport(const MTY_RenderDesc *desc, bool bottomOrigin, float *vp_x, float *vp_y, float *vp_w, float *vp_h)
 {
-	float w      = desc->cropWidth;
-	float h      = desc->cropHeight;
-	float view_w = desc->viewWidth;
-	float view_h = desc->viewHeight;
+	float w      = (float)desc->cropWidth;
+	float h      = (float)desc->cropHeight;
+	float view_w = (float)desc->viewWidth;
+	float view_h = (float)desc->viewHeight;
 	float ar     = desc->aspectRatio;
 
 	if (desc->rotation == MTY_ROTATION_90 || desc->rotation == MTY_ROTATION_270) {
-		uint32_t tmp = h;
+		float tmp = h;
 		h = w;
 		w = tmp;
 		ar = 1.0f / ar;

--- a/src/gfx/viewport.h
+++ b/src/gfx/viewport.h
@@ -8,36 +8,56 @@
 
 #include <math.h>
 
-static void mty_viewport(MTY_Rotation rotation, uint32_t w, uint32_t h,
-	uint32_t view_w, uint32_t view_h, float ar, float scale, float *vp_x,
-	float *vp_y, float *vp_w, float *vp_h)
+static void mty_viewport(const MTY_RenderDesc *desc, bool bottomOrigin, float *vp_x, float *vp_y, float *vp_w, float *vp_h)
 {
-	if (rotation == MTY_ROTATION_90 || rotation == MTY_ROTATION_270) {
+	float w      = desc->cropWidth;
+	float h      = desc->cropHeight;
+	float view_w = desc->viewWidth;
+	float view_h = desc->viewHeight;
+	float ar     = desc->aspectRatio;
+
+	if (desc->rotation == MTY_ROTATION_90 || desc->rotation == MTY_ROTATION_270) {
 		uint32_t tmp = h;
 		h = w;
 		w = tmp;
 		ar = 1.0f / ar;
 	}
 
-	uint32_t scaled_w = lrint(scale * (float) w);
-	uint32_t scaled_h = lrint(scale * (float) h);
+	float scaled_w = roundf(desc->scale * w);
+	float scaled_h = roundf(desc->scale * h);
 
 	if (scaled_w == 0 || scaled_h == 0 || view_w < scaled_w || view_h < scaled_h)
 		scaled_w = view_w;
 
-	*vp_w = (float) scaled_w;
+	*vp_w = scaled_w;
 	*vp_h = roundf(*vp_w / ar);
 
-	if (*vp_w > (float) view_w) {
-		*vp_w = (float) view_w;
+	if (*vp_w > view_w) {
+		*vp_w = view_w;
 		*vp_h = roundf(*vp_w / ar);
 	}
 
-	if (*vp_h > (float) view_h) {
-		*vp_h = (float) view_h;
+	if (*vp_h > view_h) {
+		*vp_h = view_h;
 		*vp_w = roundf(*vp_h * ar);
 	}
 
-	*vp_x = roundf(((float) view_w - *vp_w) / 2.0f);
-	*vp_y = roundf(((float) view_h - *vp_h) / 2.0f);
+	switch (desc->type)
+	{
+		default:
+		case MTY_POSITION_AUTO:
+			*vp_x = (view_w - *vp_w) / 2.0f;
+			*vp_y = (view_h - *vp_h) / 2.0f;
+			break;
+		case MTY_POSITION_FIXED:
+			*vp_x = desc->position.x;
+			*vp_y = desc->position.y;
+			break;
+	}
+
+	if (bottomOrigin)
+		*vp_y = view_h - *vp_h - *vp_y;
+
+	*vp_x = roundf(*vp_x);
+	*vp_y = roundf(*vp_y);
 }

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -98,12 +98,27 @@ typedef enum {
 	MTY_ROTATION_MAKE_32 = INT32_MAX,
 } MTY_Rotation;
 
+/// @brief Quad position type.
+typedef enum {
+	MTY_POSITION_AUTO    = 0, ///< Automatic center positioning.
+	MTY_POSITION_FIXED   = 1, ///< Position using pixel values.
+	MTY_POSITION_MAKE_32 = INT32_MAX,
+} MTY_Position;
+
+/// @brief A point with an `x` and `y` coordinate.
+typedef struct {
+	float x; ///< Horizontal position.
+	float y; ///< Vertical position
+} MTY_Point;
+
 /// @brief Description of a render operation.
 typedef struct {
 	MTY_ColorFormat format; ///< The color format of a raw image.
 	MTY_Rotation rotation;  ///< Rotation applied to the image.
 	MTY_Filter filter;      ///< Filter applied to the image.
 	MTY_Effect effect;      ///< Effect applied to the image.
+	MTY_Position type;      ///< Type of positioning configuration.
+	MTY_Point position;     ///< Position of the image in the viewport.
 	uint32_t imageWidth;    ///< The width in pixels of the image.
 	uint32_t imageHeight;   ///< The height in pixels of the image.
 	uint32_t cropWidth;     ///< Desired crop width of the image from the top left corner.
@@ -115,13 +130,10 @@ typedef struct {
 	float scale;            ///< Multiplier applied to the dimensions of the image, producing an
 	                        ///<   minimized or magnified image. This can be set to 0
 	                        ///<   if unnecessary.
+	bool layer;             ///< Should draw the quad on top of already exiting operations. 
+	                        ///<   This is required when drawing multiple quads during the
+                            ///<   same rendering loop to prevent clearing the view.
 } MTY_RenderDesc;
-
-/// @brief A point with an `x` and `y` coordinate.
-typedef struct {
-	float x; ///< Horizontal position.
-	float y; ///< Vertical position
-} MTY_Point;
 
 /// @brief A rectangle with `left`, `top`, `right`, and `bottom` coordinates.
 typedef struct {

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -130,9 +130,9 @@ typedef struct {
 	float scale;            ///< Multiplier applied to the dimensions of the image, producing an
 	                        ///<   minimized or magnified image. This can be set to 0
 	                        ///<   if unnecessary.
-	bool layer;             ///< Should draw the quad on top of already exiting operations. 
+	bool layer;             ///< Should draw the quad on top of already existing operations.
 	                        ///<   This is required when drawing multiple quads during the
-                            ///<   same rendering loop to prevent clearing the view.
+	                        ///<   same rendering loop to prevent clearing the view.
 } MTY_RenderDesc;
 
 /// @brief A rectangle with `left`, `top`, `right`, and `bottom` coordinates.

--- a/src/unix/apple/gfx/metal.m
+++ b/src/unix/apple/gfx/metal.m
@@ -253,8 +253,10 @@ bool mty_metal_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 	// Begin render pass
 	MTLRenderPassDescriptor *rpd = [MTLRenderPassDescriptor new];
 	rpd.colorAttachments[0].texture = _dest;
-	rpd.colorAttachments[0].clearColor = MTLClearColorMake(0.0, 0.0, 0.0, 1.0);
-	rpd.colorAttachments[0].loadAction = MTLLoadActionClear;
+	if (!desc->layer) {
+		rpd.colorAttachments[0].clearColor = MTLClearColorMake(0.0, 0.0, 0.0, 1.0);
+		rpd.colorAttachments[0].loadAction = MTLLoadActionClear;
+	}
 	rpd.colorAttachments[0].storeAction = MTLStoreActionStore;
 
 	id<MTLCommandBuffer> cb = [cq commandBuffer];
@@ -265,9 +267,7 @@ bool mty_metal_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	float vpx, vpy, vpw, vph;
-	mty_viewport(desc->rotation, desc->cropWidth, desc->cropHeight,
-		desc->viewWidth, desc->viewHeight, desc->aspectRatio, desc->scale,
-		&vpx, &vpy, &vpw, &vph);
+	mty_viewport(desc, false, &vpx, &vpy, &vpw, &vph);
 
 	MTLViewport vp = {0};
 	vp.originX = vpx;

--- a/src/unix/apple/gfx/metal.m
+++ b/src/unix/apple/gfx/metal.m
@@ -267,7 +267,7 @@ bool mty_metal_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	float vpx, vpy, vpw, vph;
-	mty_viewport(desc, false, &vpx, &vpy, &vpw, &vph);
+	mty_viewport(desc, &vpx, &vpy, &vpw, &vph);
 
 	MTLViewport vp = {0};
 	vp.originX = vpx;

--- a/src/windows/gfx/d3d11.c
+++ b/src/windows/gfx/d3d11.c
@@ -364,7 +364,7 @@ bool mty_d3d11_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	D3D11_VIEWPORT vp = {0};
-	mty_viewport(desc, false, &vp.TopLeftX, &vp.TopLeftY, &vp.Width, &vp.Height);
+	mty_viewport(desc, &vp.TopLeftX, &vp.TopLeftY, &vp.Width, &vp.Height);
 
 	ID3D11DeviceContext_RSSetViewports(_context, 1, &vp);
 

--- a/src/windows/gfx/d3d11.c
+++ b/src/windows/gfx/d3d11.c
@@ -364,9 +364,7 @@ bool mty_d3d11_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	D3D11_VIEWPORT vp = {0};
-	mty_viewport(desc->rotation, desc->cropWidth, desc->cropHeight,
-		desc->viewWidth, desc->viewHeight, desc->aspectRatio, desc->scale,
-		&vp.TopLeftX, &vp.TopLeftY, &vp.Width, &vp.Height);
+	mty_viewport(desc, false, &vp.TopLeftX, &vp.TopLeftY, &vp.Width, &vp.Height);
 
 	ID3D11DeviceContext_RSSetViewports(_context, 1, &vp);
 
@@ -389,8 +387,10 @@ bool mty_d3d11_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 		ID3D11DeviceContext_OMSetRenderTargets(_context, 1, &rtv, NULL);
 
-		FLOAT clear_color[4] = {0.0f, 0.0f, 0.0f, 1.0f};
-		ID3D11DeviceContext_ClearRenderTargetView(_context, rtv, clear_color);
+		if (!desc->layer) {
+			FLOAT clear_color[4] = {0.0f, 0.0f, 0.0f, 1.0f};
+			ID3D11DeviceContext_ClearRenderTargetView(_context, rtv, clear_color);
+		}
 	}
 
 	// Vertex shader

--- a/src/windows/gfx/d3d9.c
+++ b/src/windows/gfx/d3d9.c
@@ -306,18 +306,18 @@ bool mty_d3d9_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 			goto except;
 		}
 
-		e = IDirect3DDevice9_Clear(_device, 0, NULL, D3DCLEAR_TARGET, D3DCOLOR_XRGB(0, 0, 0), 1.0f, 0);
-		if (e != D3D_OK) {
-			MTY_Log("'IDirect3DDevice9_Clear' failed with HRESULT 0x%X", e);
-			goto except;
+		if (!desc->layer) {
+			e = IDirect3DDevice9_Clear(_device, 0, NULL, D3DCLEAR_TARGET, D3DCOLOR_XRGB(0, 0, 0), 1.0f, 0);
+			if (e != D3D_OK) {
+				MTY_Log("'IDirect3DDevice9_Clear' failed with HRESULT 0x%X", e);
+				goto except;
+			}
 		}
 	}
 
 	// Viewport
 	float vpx, vpy, vpw, vph;
-	mty_viewport(desc->rotation, desc->cropWidth, desc->cropHeight,
-		desc->viewWidth, desc->viewHeight, desc->aspectRatio, desc->scale,
-		&vpx, &vpy, &vpw, &vph);
+	mty_viewport(desc, false, &vpx, &vpy, &vpw, &vph);
 
 	D3DVIEWPORT9 vp = {0};
 	vp.X = lrint(vpx);

--- a/src/windows/gfx/d3d9.c
+++ b/src/windows/gfx/d3d9.c
@@ -317,7 +317,7 @@ bool mty_d3d9_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	float vpx, vpy, vpw, vph;
-	mty_viewport(desc, false, &vpx, &vpy, &vpw, &vph);
+	mty_viewport(desc, &vpx, &vpy, &vpw, &vph);
 
 	D3DVIEWPORT9 vp = {0};
 	vp.X = lrint(vpx);


### PR DESCRIPTION
Back with a proposal this time: I need to draw multiple quads in a single loop iteration (the game frame and buttons for a virtual controller), drawn at different positions of the viewport.

As far as I've seen, there were two ways to implement that:
* Either being able to configure the `MTY_RenderDesc` to describe the image to be drawn as a layer, i.e. as a new element of the end frame that will not trigger any clearing of the rendering target.
* Or adding a `MTY_RenderClear` with its `Window` version, and disabling all implicit clearing.

I chose to go for the first solution as it seemed to be less invasive on the code-base, and does not break any existing usage if the library (excluding a required `matoya.h` update on the end projects).

Also, as OpenGL is the only one with a bottom-left origin, I transform the image positions used with this GFX to make it top-left instead.

What do you think? :slightly_smiling_face: 