### PR TITLE
Add MTY_COLOR_FORMAT_RGBA

### DIFF
--- a/src/gfx/gl.c
+++ b/src/gfx/gl.c
@@ -186,13 +186,17 @@ static void gl_reload_textures(struct gl *ctx, const void *image, const MTY_Rend
 		case MTY_COLOR_FORMAT_BGRA:
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
-		case MTY_COLOR_FORMAT_BGRA5551: {
+		case MTY_COLOR_FORMAT_BGRA5551:
+		case MTY_COLOR_FORMAT_RGBA: {
 			GLenum internal = GL_RGBA;
 			GLenum format = GL_BGRA;
 			GLenum type = GL_UNSIGNED_BYTE;
 			GLint bpp = 4;
 
-			if (desc->format == MTY_COLOR_FORMAT_BGR565) {
+			if (desc->format == MTY_COLOR_FORMAT_RGBA) {
+				format = GL_RGBA;
+
+			} else if (desc->format == MTY_COLOR_FORMAT_BGR565) {
 				internal = GL_RGB;
 				format = GL_RGB;
 				type = GL_UNSIGNED_SHORT_5_6_5;

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -69,6 +69,7 @@ typedef enum {
 	MTY_COLOR_FORMAT_BGR565   = 6, ///< 5-bits blue, 6-bits green, 5-bits red.
 	MTY_COLOR_FORMAT_BGRA5551 = 7, ///< 5-bits per BGR channels, 1-bit alpha.
 	MTY_COLOR_FORMAT_AYUV     = 8, ///< 4:4:4 full W/H interleaved Y, U, V.
+	MTY_COLOR_FORMAT_RGBA     = 9, ///< 8-bits per channel RGBA.
 	MTY_COLOR_FORMAT_MAKE_32 = INT32_MAX,
 } MTY_ColorFormat;
 

--- a/src/unix/apple/gfx/metal.m
+++ b/src/unix/apple/gfx/metal.m
@@ -159,9 +159,16 @@ static void metal_reload_textures(struct metal *ctx, id<MTLDevice> device, const
 		case MTY_COLOR_FORMAT_BGRA:
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
-		case MTY_COLOR_FORMAT_BGRA5551: {
-			MTLPixelFormat format = MTLPixelFormatBGRA8Unorm;
-			uint8_t bpp = (desc->format == MTY_COLOR_FORMAT_BGRA || desc->format == MTY_COLOR_FORMAT_AYUV) ? 4 : 2;
+		case MTY_COLOR_FORMAT_BGRA5551:
+		case MTY_COLOR_FORMAT_RGBA: {
+			MTLPixelFormat format = desc->format == MTY_COLOR_FORMAT_RGBA
+				? MTLPixelFormatRGBA8Unorm
+				: MTLPixelFormatBGRA8Unorm;
+			uint8_t bpp =
+				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
+				sizeof(uint16_t);
 
 			// 16-bit packed pixel formats were not available until Big Sur
 			if (bpp == 2) {

--- a/src/windows/gfx/d3d11.c
+++ b/src/windows/gfx/d3d11.c
@@ -279,10 +279,18 @@ static HRESULT d3d11_reload_textures(struct d3d11 *ctx, ID3D11Device *device, ID
 		case MTY_COLOR_FORMAT_BGRA:
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
-		case MTY_COLOR_FORMAT_BGRA5551: {
-			DXGI_FORMAT format = desc->format == MTY_COLOR_FORMAT_BGR565 ? DXGI_FORMAT_B5G6R5_UNORM :
-				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? DXGI_FORMAT_B5G5R5A1_UNORM : DXGI_FORMAT_B8G8R8A8_UNORM;
-			uint8_t bpp = (desc->format == MTY_COLOR_FORMAT_BGRA || desc->format == MTY_COLOR_FORMAT_AYUV) ? 4 : 2;
+		case MTY_COLOR_FORMAT_BGRA5551:
+		case MTY_COLOR_FORMAT_RGBA: {
+			DXGI_FORMAT format =
+				desc->format == MTY_COLOR_FORMAT_BGR565   ? DXGI_FORMAT_B5G6R5_UNORM   :
+				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? DXGI_FORMAT_B5G5R5A1_UNORM :
+				desc->format == MTY_COLOR_FORMAT_RGBA     ? DXGI_FORMAT_R8G8B8A8_UNORM :
+				DXGI_FORMAT_B8G8R8A8_UNORM;
+			uint8_t bpp =
+				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
+				sizeof(uint16_t);
 
 			// BGRA
 			HRESULT e = d3d11_refresh_resource(&ctx->staging[0], device, format, desc->cropWidth, desc->cropHeight);

--- a/src/windows/gfx/d3d9.c
+++ b/src/windows/gfx/d3d9.c
@@ -217,10 +217,18 @@ static HRESULT d3d9_reload_textures(struct d3d9 *ctx, IDirect3DDevice9 *device,
 		case MTY_COLOR_FORMAT_BGRA:
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
-		case MTY_COLOR_FORMAT_BGRA5551: {
-			D3DFORMAT format = desc->format == MTY_COLOR_FORMAT_BGR565 ? D3DFMT_R5G6B5 :
-				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? D3DFMT_X1R5G5B5 : D3DFMT_A8R8G8B8;
-			uint8_t bpp = (desc->format == MTY_COLOR_FORMAT_BGRA || desc->format == MTY_COLOR_FORMAT_AYUV) ? 4 : 2;
+		case MTY_COLOR_FORMAT_BGRA5551:
+		case MTY_COLOR_FORMAT_RGBA: {
+			D3DFORMAT format =
+				desc->format == MTY_COLOR_FORMAT_BGR565   ? D3DFMT_R5G6B5   :
+				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? D3DFMT_X1R5G5B5 :
+				desc->format == MTY_COLOR_FORMAT_RGBA     ? D3DFMT_A8B8G8R8 :
+				D3DFMT_A8R8G8B8;
+			uint8_t bpp =
+				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
+				sizeof(uint16_t);
 
 			// BGRA
 			HRESULT e = d3d9_refresh_resource(&ctx->staging[0], device, format, desc->cropWidth, desc->cropHeight);


### PR DESCRIPTION
WebGL does not seem to support BGRA color format. This PR is to add support for RGBA color format, which is probably the most direct (and easy to convert) alternative. Tested and working with all available GFX.