### PR TITLE
Improve touch gestures on Web

### DIFF
--- a/src/matoya.h
+++ b/src/matoya.h
@@ -634,7 +634,7 @@ typedef struct {
 typedef struct {
 	int32_t id;        ///< A unique identifier representing the pointer used.
 	                   ///<   This is useful to track touch-based events. 
-					   ///<   Mouse events will always have 0. 
+	                   ///<   Mouse events will always have 0. 
 	MTY_Button button; ///< The button that has been pressed or released.
 	int32_t x;         ///< Horizontal position in the client area window.
 	int32_t y;         ///< Vertical position in the client area of the window.
@@ -645,7 +645,7 @@ typedef struct {
 typedef struct {
 	int32_t id;    ///< A unique identifier representing the pointer used.
 	               ///<   This is useful to track touch-based events. 
-				   ///<   Mouse events will always have 0. 
+	               ///<   Mouse events will always have 0. 
 	int32_t x;     ///< If `relative` is true, the horizontal delta since the previous motion
 	               ///<   event, otherwise the horizontal position in the window's client area.
 	int32_t y;     ///< In `relative` is true, the vertical delta since the previous motion event,

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -632,6 +632,9 @@ typedef struct {
 
 /// @brief Button event.
 typedef struct {
+	int32_t id;        ///< A unique identifier representing the pointer used.
+	                   ///<   This is useful to track touch-based events. 
+					   ///<   Mouse events will always have 0. 
 	MTY_Button button; ///< The button that has been pressed or released.
 	int32_t x;         ///< Horizontal position in the client area window.
 	int32_t y;         ///< Vertical position in the client area of the window.
@@ -640,6 +643,9 @@ typedef struct {
 
 /// @brief Motion event.
 typedef struct {
+	int32_t id;    ///< A unique identifier representing the pointer used.
+	               ///<   This is useful to track touch-based events. 
+				   ///<   Mouse events will always have 0. 
 	int32_t x;     ///< If `relative` is true, the horizontal delta since the previous motion
 	               ///<   event, otherwise the horizontal position in the window's client area.
 	int32_t y;     ///< In `relative` is true, the vertical delta since the previous motion event,

--- a/src/unix/web/app.c
+++ b/src/unix/web/app.c
@@ -41,10 +41,11 @@ static void __attribute__((constructor)) app_global_init(void)
 
 // Window events
 
-static void window_motion(MTY_App *ctx, bool relative, int32_t x, int32_t y)
+static void window_motion(MTY_App *ctx, int32_t id, bool relative, int32_t x, int32_t y)
 {
 	MTY_Event evt = {0};
 	evt.type = MTY_EVENT_MOTION;
+	evt.motion.id = id;
 	evt.motion.relative = relative;
 	evt.motion.x = x;
 	evt.motion.y = y;
@@ -68,10 +69,11 @@ static void window_move(MTY_App *ctx)
 	ctx->event_func(&evt, ctx->opaque);
 }
 
-static void window_button(MTY_App *ctx, bool pressed, int32_t button, int32_t x, int32_t y)
+static void window_button(MTY_App *ctx, int32_t id, bool pressed, int32_t button, int32_t x, int32_t y)
 {
 	MTY_Event evt = {0};
 	evt.type = MTY_EVENT_BUTTON;
+	evt.button.id = id;
 	evt.button.pressed = pressed;
 	evt.button.button =
 		button == 0 ? MTY_BUTTON_LEFT :

--- a/src/unix/web/matoya.js
+++ b/src/unix/web/matoya.js
@@ -997,10 +997,10 @@ const MTY_WEB_API = {
 
 		var touch_started = function (ev) {
 			const touches = ev.changedTouches;
-		
+
 			for (var i = 0; i < touches.length; i++) {
 				const touch = touches[i];
-		
+
 				currentTouches.push({
 					identifier: touch.identifier,
 					clientX: touch.clientX,
@@ -1011,40 +1011,40 @@ const MTY_WEB_API = {
 				MTY_CFunc(mouse_button)(app, touch.identifier, true, 0, mty_scaled(touch.clientX), mty_scaled(touch.clientY));
 			}
 		};
-		
+
 		var touch_moved = function (ev) {
 			const touches = ev.changedTouches;
 
 			for (var i = 0; i < touches.length; i++) {
 				const newTouch = touches[i];
-				const touchIndex = currentTouches.findIndex(touch => touch.identifier == newTouch.identifier); 
-		
+				const touchIndex = currentTouches.findIndex(touch => touch.identifier == newTouch.identifier);
+
 				if (touchIndex != -1) {
 					const touch = currentTouches[touchIndex];
-	
+
 					let x = mty_scaled(newTouch.clientX);
 					let y = mty_scaled(newTouch.clientY);
-	
+
 					if (MTY.relative) {
 						x = newTouch.clientX - touch.clientX;
 						y = newTouch.clientY - touch.clientY;
 					}
-	
+
 					touch.clientX = x;
 					touch.clientY = y;
-	
+
 					MTY_CFunc(mouse_motion)(app, touch.identifier, MTY.relative, touch.clientX, touch.clientY);
 				}
 			}
 		};
-		
+
 		var touch_ended = function (ev) {
 			const touches = ev.changedTouches;
-		
+
 			for (var i = 0; i < touches.length; i++) {
 				const newTouch = touches[i];
-				const touchIndex = currentTouches.findIndex(touch => touch.identifier == newTouch.identifier); 
-		
+				const touchIndex = currentTouches.findIndex(touch => touch.identifier == newTouch.identifier);
+
 				if (touchIndex != -1) {
 					const touch = currentTouches[touchIndex];
 
@@ -1054,7 +1054,7 @@ const MTY_WEB_API = {
 				}
 			}
 		};
-		
+
 		MTY.gl.canvas.addEventListener('touchstart', function(ev) {
 			ev.preventDefault();
 			touch_started(ev);

--- a/src/unix/web/web.h
+++ b/src/unix/web/web.h
@@ -15,8 +15,8 @@ typedef void (*WEB_FREE)(void *ptr);
 typedef void (*WEB_CONTROLLER)(MTY_App *ctx, uint32_t id, uint32_t state, uint32_t buttons,
 	float lx, float ly, float rx, float ry, float lt, float rt);
 typedef void (*WEB_MOVE)(MTY_App *ctx);
-typedef void (*WEB_MOTION)(MTY_App *ctx, bool relative, int32_t x, int32_t y);
-typedef void (*WEB_BUTTON)(MTY_App *ctx, bool pressed, int32_t button, int32_t x, int32_t y);
+typedef void (*WEB_MOTION)(MTY_App *ctx, int32_t id, bool relative, int32_t x, int32_t y);
+typedef void (*WEB_BUTTON)(MTY_App *ctx, int32_t id, bool pressed, int32_t button, int32_t x, int32_t y);
 typedef void (*WEB_SCROLL)(MTY_App *ctx, int32_t x, int32_t y);
 typedef bool (*WEB_KEY)(MTY_App *ctx, bool pressed, MTY_Key key, const char *text, uint32_t mods);
 typedef void (*WEB_FOCUS)(MTY_App *ctx, bool focus);


### PR DESCRIPTION
Adds touch gestures handling on the Web platform. this was originally a commit in #39, but I felt like this required its own proposal.

Touch gestures are considered the same as mouse events, except that an identifier is passed to the C hook, allowing to keep track of the pointer in use. Regular mouse events will have 0 filled in this identifier, as their can only be one pointer of this kind.

Please let me know if this is OK for you, or if you see something that can be improved!