### PR TITLE
Add scaling capability on Android platform

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -39,6 +39,7 @@ LOCAL_CFLAGS = $(DEFS) $(FLAGS)
 LOCAL_SRC_FILES := \
 	src/app.c \
 	src/crypto.c \
+	src/cursor.c \
 	src/file.c \
 	src/hash.c \
 	src/image.c \

--- a/Android.mk
+++ b/Android.mk
@@ -53,6 +53,7 @@ LOCAL_SRC_FILES := \
 	src/tlocal.c \
 	src/tls.c \
 	src/version.c \
+	src/zoom.c \
 	src/gfx/gl.c \
 	src/gfx/gl-ui.c \
 	src/hid/utils.c \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,6 +16,7 @@ NAME = libmatoya
 OBJS = \
 	src/app.o \
 	src/crypto.o \
+	src/cursor.o \
 	src/file.o \
 	src/hash.o \
 	src/image.o \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -30,6 +30,7 @@ OBJS = \
 	src/tlocal.o \
 	src/tls.o \
 	src/version.o \
+	src/zoom.o \
 	src/gfx/gl.o \
 	src/gfx/gl-ui.o \
 	src/hid/utils.o \

--- a/makefile
+++ b/makefile
@@ -39,6 +39,7 @@ OBJS = \
 	src\tlocal.obj \
 	src\tls.obj \
 	src\version.obj \
+	src\zoom.obj \
 	src\gfx\gl.obj \
 	src\gfx\gl-ui.obj \
 	src\hid\hid.obj \

--- a/makefile
+++ b/makefile
@@ -25,6 +25,7 @@ NAME = matoya
 OBJS = \
 	src\app.obj \
 	src\crypto.obj \
+	src\cursor.obj \
 	src\file.obj \
 	src\hash.obj \
 	src\image.obj \

--- a/src/app.c
+++ b/src/app.c
@@ -151,6 +151,8 @@ void MTY_PrintEvent(const MTY_Event *evt)
 		PEVENT(MTY_EVENT_HOTKEY, evt, "id: %u", evt->hotkey);
 		PEVENT(MTY_EVENT_TEXT, evt, "text: %s", evt->text);
 		PEVENT(MTY_EVENT_SCROLL, evt, "x: %d, y: %d, pixels: %u", evt->scroll.x, evt->scroll.y, evt->scroll.pixels);
+		PEVENT(MTY_EVENT_SCALE, evt, "factor: %f, focusX: %f, focusY: %f", evt->scale.factor, 
+			evt->scale.focusX, evt->scale.focusY);
 		PEVENT(MTY_EVENT_FOCUS, evt, "focus: %u", evt->focus);
 		PEVENT(MTY_EVENT_MOTION, evt, "x: %d, y: %d, relative: %u, synth: %u", evt->motion.x,
 			evt->motion.y, evt->motion.relative, evt->motion.synth);

--- a/src/app.c
+++ b/src/app.c
@@ -47,8 +47,11 @@ void MTY_WindowDrawQuad(MTY_App *app, MTY_Window window, const void *image, cons
 	struct gfx_ctx *gfx_ctx = NULL;
 	MTY_GFX api = mty_window_get_gfx(app, window, &gfx_ctx);
 
+	MTY_RenderDesc mutated = *desc;
+	MTY_WindowGetSize(app, window, &mutated.displayWidth, &mutated.displayHeight);
+
 	if (api != MTY_GFX_NONE)
-		GFX_CTX_API[api].draw_quad(gfx_ctx, image, desc);
+		GFX_CTX_API[api].draw_quad(gfx_ctx, image, &mutated);
 }
 
 void MTY_WindowDrawUI(MTY_App *app, MTY_Window window, const MTY_DrawData *dd)

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -68,8 +68,8 @@ void MTY_CursorDraw(MTY_Cursor *ctx, MTY_Window window)
 
 	desc.type = MTY_POSITION_FIXED;
 	desc.scale = ctx->scale;
-	desc.imageX = ctx->x - ctx->hotX;
-	desc.imageY = ctx->y - ctx->hotY;
+	desc.imageX = (int32_t) (ctx->x - (ctx->hotX * desc.scale));
+	desc.imageY = (int32_t) (ctx->y - (ctx->hotY * desc.scale));
 
 	MTY_WindowDrawQuad(ctx->app, window, ctx->image, &desc);
 }

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -58,7 +58,7 @@ void MTY_CursorDraw(MTY_Cursor *ctx, MTY_Window window)
 	
     MTY_RenderDesc desc = {0};
 
-	desc.format = MTY_COLOR_FORMAT_BGRA;
+	desc.format = MTY_COLOR_FORMAT_RGBA;
 	desc.cropWidth = ctx->width;
 	desc.cropHeight = ctx->height;
 	desc.imageWidth = ctx->width;

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -1,0 +1,87 @@
+#include "matoya.h"
+
+struct MTY_Cursor {
+    MTY_App *app;
+	void *image;
+	uint32_t width;
+	uint32_t height;
+	uint16_t hotX;
+	uint16_t hotY;
+	int32_t x;
+	int32_t y;
+	float scale;
+};
+
+MTY_Cursor *MTY_CursorCreate(MTY_App *app)
+{
+    MTY_Cursor *ctx = MTY_Alloc(1, sizeof(MTY_Cursor));
+
+    ctx->app = app;
+
+    return ctx;
+}
+
+void MTY_CursorSetHotspot(MTY_Cursor *ctx, uint16_t hotX, uint16_t hotY)
+{
+    ctx->hotX = hotX;
+    ctx->hotY = hotY;
+}
+
+void MTY_CursorSetImage(MTY_Cursor *ctx, const void *data, size_t size)
+{
+	if (ctx->image)
+		MTY_Free(ctx->image);
+
+    ctx->image = MTY_DecompressImage(data, size, &ctx->width, &ctx->height);
+}
+
+void MTY_CursorMove(MTY_Cursor *ctx, int32_t x, int32_t y, float scale)
+{
+    ctx->scale = scale;
+    ctx->x = x;
+    ctx->y = y;
+}
+
+void MTY_CursorMoveFromZoom(MTY_Cursor *ctx, MTY_Zoom *zoom)
+{
+	float scale = MTY_ZoomGetScale(zoom);
+	int32_t cursor_x = MTY_ZoomGetCursorX(zoom);
+	int32_t cursor_y = MTY_ZoomGetCursorY(zoom);
+	
+	MTY_CursorMove(ctx, cursor_x, cursor_y, scale);
+}
+
+void MTY_CursorDraw(MTY_Cursor *ctx, MTY_Window window)
+{
+	if (!ctx->image)
+		return;
+	
+    MTY_RenderDesc desc = {0};
+
+	desc.format = MTY_COLOR_FORMAT_BGRA;
+	desc.cropWidth = ctx->width;
+	desc.cropHeight = ctx->height;
+	desc.imageWidth = ctx->width;
+	desc.imageHeight = ctx->width;
+	desc.aspectRatio = (float) ctx->width / (float) ctx->height;
+	desc.blend = true;
+
+	desc.type = MTY_POSITION_FIXED;
+	desc.scale = ctx->scale;
+	desc.imageX = ctx->x - ctx->hotX;
+	desc.imageY = ctx->y - ctx->hotY;
+
+	MTY_WindowDrawQuad(ctx->app, window, ctx->image, &desc);
+}
+
+void MTY_CursorDestroy(MTY_Cursor **ctx)
+{
+    if (!(*ctx))
+        return;
+
+    if ((*ctx)->image)
+        MTY_Free((*ctx)->image);
+
+    MTY_Free(*ctx);
+    *ctx = NULL;
+}

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -59,6 +59,7 @@ void MTY_CursorDraw(MTY_Cursor *ctx, MTY_Window window)
     MTY_RenderDesc desc = {0};
 
 	desc.format = MTY_COLOR_FORMAT_RGBA;
+	desc.filter = MTY_FILTER_LINEAR;
 	desc.cropWidth = ctx->width;
 	desc.cropHeight = ctx->height;
 	desc.imageWidth = ctx->width;

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -2,6 +2,7 @@
 
 struct MTY_Cursor {
     MTY_App *app;
+	bool enabled;
 	void *image;
 	uint32_t width;
 	uint32_t height;
@@ -17,8 +18,14 @@ MTY_Cursor *MTY_CursorCreate(MTY_App *app)
     MTY_Cursor *ctx = MTY_Alloc(1, sizeof(MTY_Cursor));
 
     ctx->app = app;
+	ctx->enabled = true;
 
     return ctx;
+}
+
+void MTY_CursorEnable(MTY_Cursor *ctx, bool enable)
+{
+	ctx->enabled = enable;
 }
 
 void MTY_CursorSetHotspot(MTY_Cursor *ctx, uint16_t hotX, uint16_t hotY)
@@ -53,7 +60,7 @@ void MTY_CursorMoveFromZoom(MTY_Cursor *ctx, MTY_Zoom *zoom)
 
 void MTY_CursorDraw(MTY_Cursor *ctx, MTY_Window window)
 {
-	if (!ctx->image)
+	if (!ctx->image || !ctx->enabled)
 		return;
 	
     MTY_RenderDesc desc = {0};

--- a/src/gfx/gl.c
+++ b/src/gfx/gl.c
@@ -184,6 +184,7 @@ static void gl_reload_textures(struct gl *ctx, const void *image, const MTY_Rend
 {
 	switch (desc->format) {
 		case MTY_COLOR_FORMAT_BGRA:
+		case MTY_COLOR_FORMAT_RGBA: 
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
 		case MTY_COLOR_FORMAT_BGRA5551: {
@@ -192,7 +193,11 @@ static void gl_reload_textures(struct gl *ctx, const void *image, const MTY_Rend
 			GLenum type = GL_UNSIGNED_BYTE;
 			GLint bpp = 4;
 
-			if (desc->format == MTY_COLOR_FORMAT_BGR565) {
+			if (desc->format == MTY_COLOR_FORMAT_RGBA) {
+				internal = GL_RGBA;
+				format = GL_RGBA;
+
+			} else if (desc->format == MTY_COLOR_FORMAT_BGR565) {
 				internal = GL_RGB;
 				format = GL_RGB;
 				type = GL_UNSIGNED_SHORT_5_6_5;

--- a/src/gfx/gl.c
+++ b/src/gfx/gl.c
@@ -187,7 +187,7 @@ static void gl_reload_textures(struct gl *ctx, const void *image, const MTY_Rend
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
 		case MTY_COLOR_FORMAT_BGRA5551: {
-			GLenum internal = GL_RGBA;
+			GLenum internal = GL_BGRA;
 			GLenum format = GL_BGRA;
 			GLenum type = GL_UNSIGNED_BYTE;
 			GLint bpp = 4;

--- a/src/gfx/gl.c
+++ b/src/gfx/gl.c
@@ -285,8 +285,17 @@ bool mty_gl_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 	if (_dest)
 		glBindFramebuffer(GL_FRAMEBUFFER, _dest);
 
+	// Blending capability
+	if (desc->blend) {
+		glEnable(GL_BLEND);
+		glBlendEquation(GL_FUNC_ADD);
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+	} else {
+		glDisable(GL_BLEND);
+	}
+	
 	// Context state, set vertex and fragment shaders
-	glDisable(GL_BLEND);
 	glDisable(GL_CULL_FACE);
 	glDisable(GL_DEPTH_TEST);
 	glDisable(GL_SCISSOR_TEST);

--- a/src/gfx/gl.c
+++ b/src/gfx/gl.c
@@ -301,8 +301,10 @@ bool mty_gl_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 	glVertexAttribPointer(ctx->loc_uv,  2, GL_FLOAT, GL_FALSE, 4 * sizeof(GLfloat), (void *) (2 * sizeof(GLfloat)));
 
 	// Clear
-	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-	glClear(GL_COLOR_BUFFER_BIT);
+	if (desc->clear) {
+		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+		glClear(GL_COLOR_BUFFER_BIT);
+	}
 
 	// Fragment shader
 	for (uint8_t x = 0; x < GL_NUM_STAGING; x++) {

--- a/src/gfx/gl.c
+++ b/src/gfx/gl.c
@@ -277,9 +277,7 @@ bool mty_gl_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	float vpx, vpy, vpw, vph;
-	mty_viewport(desc->rotation, desc->cropWidth, desc->cropHeight,
-		desc->viewWidth, desc->viewHeight, desc->aspectRatio, desc->scale,
-		&vpx, &vpy, &vpw, &vph);
+	mty_viewport(desc, &vpx, &vpy, &vpw, &vph, true);
 
 	glViewport(lrint(vpx), lrint(vpy) + GL_ORIGIN_Y, lrint(vpw), lrint(vph));
 

--- a/src/gfx/viewport.h
+++ b/src/gfx/viewport.h
@@ -8,36 +8,58 @@
 
 #include <math.h>
 
-static void mty_viewport(MTY_Rotation rotation, uint32_t w, uint32_t h,
-	uint32_t view_w, uint32_t view_h, float ar, float scale, float *vp_x,
-	float *vp_y, float *vp_w, float *vp_h)
+static void mty_viewport(const MTY_RenderDesc *desc, float *vp_x, float *vp_y, float *vp_w, float *vp_h, bool transform_origin)
 {
-	if (rotation == MTY_ROTATION_90 || rotation == MTY_ROTATION_270) {
-		uint32_t tmp = h;
+	float w      = (float)desc->cropWidth;
+	float h      = (float)desc->cropHeight;
+	float view_w = (float)desc->viewWidth;
+	float view_h = (float)desc->viewHeight;
+	float ar     = desc->aspectRatio;
+
+	if (desc->rotation == MTY_ROTATION_90 || desc->rotation == MTY_ROTATION_270) {
+		float tmp = h;
 		h = w;
 		w = tmp;
 		ar = 1.0f / ar;
 	}
 
-	uint32_t scaled_w = lrint(scale * (float) w);
-	uint32_t scaled_h = lrint(scale * (float) h);
+	float scaled_w = roundf(desc->scale * w);
+	float scaled_h = roundf(desc->scale * h);
 
-	if (scaled_w == 0 || scaled_h == 0 || view_w < scaled_w || view_h < scaled_h)
-		scaled_w = view_w;
+	switch (desc->type)	{
+		default:
+		case MTY_POSITION_AUTO:
+			if (scaled_w == 0 || scaled_h == 0 || view_w < scaled_w || view_h < scaled_h)
+				scaled_w = view_w;
 
-	*vp_w = (float) scaled_w;
-	*vp_h = roundf(*vp_w / ar);
+			*vp_w = scaled_w;
+			*vp_h = roundf(*vp_w / ar);
 
-	if (*vp_w > (float) view_w) {
-		*vp_w = (float) view_w;
-		*vp_h = roundf(*vp_w / ar);
+			if (*vp_w > view_w) {
+				*vp_w = view_w;
+				*vp_h = roundf(*vp_w / ar);
+			}
+
+			if (*vp_h > view_h) {
+				*vp_h = view_h;
+				*vp_w = roundf(*vp_h * ar);
+			}
+
+			*vp_x = (view_w - *vp_w) / 2.0f;
+			*vp_y = (view_h - *vp_h) / 2.0f;
+			break;
+		case MTY_POSITION_FIXED:
+			*vp_w = scaled_w;
+			*vp_h = scaled_h;
+
+			*vp_x = (float)desc->imageX;
+			*vp_y = (float)desc->imageY;
+
+			if (transform_origin)
+				*vp_y = desc->displayHeight - scaled_h - *vp_y;
+			break;
 	}
 
-	if (*vp_h > (float) view_h) {
-		*vp_h = (float) view_h;
-		*vp_w = roundf(*vp_h * ar);
-	}
-
-	*vp_x = roundf(((float) view_w - *vp_w) / 2.0f);
-	*vp_y = roundf(((float) view_h - *vp_h) / 2.0f);
+	*vp_x = roundf(*vp_x);
+	*vp_y = roundf(*vp_y);
 }

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -70,6 +70,7 @@ typedef enum {
 	MTY_COLOR_FORMAT_BGR565   = 6, ///< 5-bits blue, 6-bits green, 5-bits red.
 	MTY_COLOR_FORMAT_BGRA5551 = 7, ///< 5-bits per BGR channels, 1-bit alpha.
 	MTY_COLOR_FORMAT_AYUV     = 8, ///< 4:4:4 full W/H interleaved Y, U, V.
+	MTY_COLOR_FORMAT_RGBA     = 9, ///< 8-bits per channel RGBA.
 	MTY_COLOR_FORMAT_MAKE_32 = INT32_MAX,
 } MTY_ColorFormat;
 

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3643,17 +3643,16 @@ MTY_ZoomIsRelative(MTY_Zoom *ctx);
 MTY_EXPORT void 
 MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative);
 
-/// @brief Set the current context mode.
+/// @brief Set whether the context uses trackpad mode.
 /// @details Set the behavior the context must adopt when processing data:
-///   * MTY_INPUT_MODE_UNSPECIFIED: defaults to MTY_INPUT_MODE_TOUCHSCREEN.
-///   * MTY_INPUT_MODE_TOUCHSCREEN: The zoomed area does not move and the cursor
-///     is positioned within this area. 
-///   * MTY_INPUT_MODE_TRACKPAD: The cursor is moved relatively to its previous
+///   * When enabled, the cursor is moved relatively to its previous
 ///     position and the zoomed area is panned if the cursor goes out.
+///   * When disabled, the zoomed area does not move and the cursor is
+///     positioned within this area. 
 /// @param ctx The MTY_Zoom.
-/// @param mode The new input mode.
+/// @param enable True to enable trackpad mode, false otherwise.
 MTY_EXPORT void 
-MTY_ZoomSetMode(MTY_Zoom *ctx, MTY_InputMode mode);
+MTY_ZoomEnableTrackpad(MTY_Zoom *ctx, bool enable);
 
 /// @brief Check if the cursor has moved since the previous call.
 /// @param ctx The MTY_Zoom.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3641,8 +3641,14 @@ MTY_ZoomIsRelative(MTY_Zoom *ctx);
 ///   relative coordinates (e.g. 1 will be tranformed to 0.5 if the current scale factor is 2).
 /// @param ctx The MTY_Zoom.
 /// @param scaling True when relative, otherwise false.
-MTY_EXPORT void 
+MTY_EXPORT void
 MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative);
+
+/// @brief Get whether the context uses trackpad mode.
+/// @param ctx The MTY_Zoom.
+/// @returns True if trackpad mode is enabled, false otherwise.
+MTY_EXPORT bool
+MTY_ZoomIsTrackpadEnabled(MTY_Zoom *ctx);
 
 /// @brief Set whether the context uses trackpad mode.
 /// @details Set the behavior the context must adopt when processing data:
@@ -3652,13 +3658,13 @@ MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative);
 ///     positioned within this area. 
 /// @param ctx The MTY_Zoom.
 /// @param enable True to enable trackpad mode, false otherwise.
-MTY_EXPORT void 
+MTY_EXPORT void
 MTY_ZoomEnableTrackpad(MTY_Zoom *ctx, bool enable);
 
 /// @brief Check if the cursor has moved since the previous call.
 /// @param ctx The MTY_Zoom.
 /// @returns True if the cursor has moved, false otherwise.
-MTY_EXPORT bool 
+MTY_EXPORT bool
 MTY_ZoomHasMoved(MTY_Zoom *ctx);
 
 /// @brief Check if the context recommends to show a cursor.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3537,33 +3537,31 @@ typedef struct MTY_Zoom MTY_Zoom;
 MTY_EXPORT MTY_Zoom *
 MTY_ZoomCreate();
 
-/// @brief Update the context with the image size.
-/// @details Process all the data accumulated by MTY_ZoomFeed() to produce
-///   usable scaling factor and image coordinates. This method also resets
-///   this accumulation.
+/// @brief Update the context with the window and image sizes.
+/// @details Reset and compute initial scaling data for the provided metrics.
+///   This function has not effect in provided metrics are the same as the ones
+///   provided to the previous call of MTY_ZoomUpdate().
 /// @param ctx The MTY_Zoom.
 /// @param window_w The window width.
 /// @param window_h The window height.
 /// @param imageWidth The image width.
 /// @param imageHeight The image height.
 MTY_EXPORT void 
-MTY_ZoomProcess(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight, uint32_t imageWidth, uint32_t imageHeight);
+MTY_ZoomUpdate(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight, uint32_t imageWidth, uint32_t imageHeight);
 
 /// @brief Apply a scaling data to the context.
-/// @details Update the context with newly acquired scaling gesture data.
-///   This method accumulate new values when scaling is enabled, and overwrite them 
-///   when scaling is disabled.
+/// @details Update the context according to the provided scaling data.
 /// @param ctx The MTY_Zoom.
 /// @param scaleFactor The new relative scale factor.
 /// @param focusX The new horizontal coordinate of the focal point.
 /// @param focusY The new vertical coordinate of the focal point.
 MTY_EXPORT void 
-MTY_ZoomFeed(MTY_Zoom *ctx, float scaleFactor, float focusX, float focusY);
+MTY_ZoomScale(MTY_Zoom *ctx, float scaleFactor, float focusX, float focusY);
 
 /// @brief Notify the context of a cursor move.
 /// @details Calling this function allows to keep track of the cursor movement.
-///   This is required in relative mode, and optional in absolute mode. When a move
-///   starts, the coordinates are used as the new gesture origin.
+///   This is required in relative mode, and recommended in absolute mode to keep
+///   track of the cursor at any time.
 /// @param ctx The MTY_Zoom.
 /// @param x The new X position of the cursor.
 /// @param y The new Y position of the cursor.
@@ -3585,7 +3583,7 @@ MTY_ZoomTranformX(MTY_Zoom *ctx, int32_t value);
 MTY_EXPORT int32_t 
 MTY_ZoomTranformY(MTY_Zoom *ctx, int32_t value);
 
-/// @brief Get the most recently computed scale value.
+/// @brief Get the most recently computed image scale value.
 /// @param ctx The MTY_Zoom.
 /// @returns The computed scale value.
 MTY_EXPORT float 
@@ -3623,29 +3621,34 @@ MTY_ZoomGetCursorY(MTY_Zoom *ctx);
 MTY_EXPORT void 
 MTY_ZoomSetScaling(MTY_Zoom *ctx, bool scaling);
 
-/// @brief Return whether a scaling gesture is in progress or not.
+/// @brief Check whether a scaling gesture is in progress or not.
 /// @param ctx The MTY_Zoom.
 /// @returns True when scaling, otherwise false.
 MTY_EXPORT bool 
 MTY_ZoomIsScaling(MTY_Zoom *ctx);
 
-/// @brief Sets whether the context is in relative mode or not.
-/// @details In absolute mode, the zoomed area does not move and the cursor if positioned
-///   within this area. In relative mode, the cursor is moved relatively to its previous 
-///   position and the zoomed area is panned if the cursor goes out.
+/// @brief Set the current context mode.
+/// @details Set the behavior the context must adopt when processing data:
+///   * MTY_INPUT_MODE_UNSPECIFIED: defaults to MTY_INPUT_MODE_TOUCHSCREEN.
+///   * MTY_INPUT_MODE_TOUCHSCREEN: The zoomed area does not move and the cursor
+///     is positioned within this area. 
+///   * MTY_INPUT_MODE_TRACKPAD: The cursor is moved relatively to its previous
+///     position and the zoomed area is panned if the cursor goes out.
 /// @param ctx The MTY_Zoom.
-/// @param relative Whether the context is in relative mode or not.
+/// @param mode The new input mode.
 MTY_EXPORT void 
-MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative);
+MTY_ZoomSetMode(MTY_Zoom *ctx, MTY_InputMode mode);
 
-/// @brief Return whether a the context is in relative mode or not.
+/// @brief Check if the context recommends to show a cursor.
+/// @details Currently, the context will recommend the show a cursor when the mode is
+///   MTY_INPUT_MODE_TRACKPAD, and to hide it otherwise.
 /// @param ctx The MTY_Zoom.
-/// @returns True when in relative mode, otherwise false.
+/// @returns True is the cursor should be shown, false otherwise.
 MTY_EXPORT bool 
-MTY_ZoomIsRelative(MTY_Zoom *ctx);
+MTY_ZoomShouldShowCursor(MTY_Zoom *ctx);
 
 /// @brief Set the scale limits of the context.
-/// @details This must be called before the first call to MTY_ZoomProcess(). If not, the
+/// @details This must be called before the first call to MTY_ZoomUpdate(). If not, the
 ///   change will only have effect after the next context reset, occuring after a window
 ///   or image resize. By default, the minimum is 1 (100%) and the maximum is 4 (400%).
 /// @param ctx The MTY_Zoom.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -349,6 +349,7 @@ typedef enum {
 	MTY_EVENT_BACK         = 19, ///< The mobile back command has been triggered.
 	MTY_EVENT_SIZE         = 20, ///< The size of a window has changed.
 	MTY_EVENT_MOVE         = 21, ///< The window's top left corner has moved.
+	MTY_EVENT_SCALE        = 22, ///< The scale factor has been changed.
 	MTY_EVENT_MAKE_32      = INT32_MAX,
 } MTY_EventType;
 
@@ -629,6 +630,14 @@ typedef enum {
 	MTY_CONTEXT_STATE_MAKE_32 = INT32_MAX,
 } MTY_ContextState;
 
+/// @brief State of a scaling gesture.
+typedef enum {
+	MTY_SCALE_STATE_ONGOING = 0, ///< The scaling gesture is in progress.
+	MTY_SCALE_STATE_START   = 1, ///< The scaling gesture has just started.
+	MTY_SCALE_STATE_STOP    = 2, ///< The scaling gesture has just ended.
+	MTY_SCALE_STATE_MAKE_32 = INT32_MAX,
+} MTY_ScaleState;
+
 /// @brief Key event.
 typedef struct {
 	MTY_Key key;  ///< The key that has been pressed or released.
@@ -642,6 +651,14 @@ typedef struct {
 	int32_t y;   ///< Vertical scroll value.
 	bool pixels; ///< The scroll values are expressed in exact pixels.
 } MTY_ScrollEvent;
+
+/// @brief Scale event.
+typedef struct {
+	MTY_ScaleState state; ///< Current state of the scaling gesture.
+	float factor;         ///< The relative scale factor.
+	float focusX;         ///< The horizontal focal point position.
+	float focusY;         ///< The vertical focal point position.
+} MTY_ScaleEvent;
 
 /// @brief Button event.
 typedef struct {
@@ -710,6 +727,7 @@ typedef struct MTY_Event {
 		MTY_ControllerEvent controller; ///< Valid on MTY_EVENT_CONTROLLER, MTY_EVENT_CONNECT, and
 		                                ///<   MTY_EVENT_DISCONNECT.
 		MTY_ScrollEvent scroll;         ///< Valid on MTY_EVENT_SCROLL.
+		MTY_ScaleEvent scale;           ///< Valid on MTY_EVENT_SCALE.
 		MTY_ButtonEvent button;         ///< Valid on MTY_EVENT_BUTTON.
 		MTY_MotionEvent motion;         ///< Valid on MTY_EVENT_MOTION.
 		MTY_DropEvent drop;             ///< Valid on MTY_EVENT_DROP.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -99,18 +99,30 @@ typedef enum {
 	MTY_ROTATION_MAKE_32 = INT32_MAX,
 } MTY_Rotation;
 
+/// @brief Quad position type.
+typedef enum {
+	MTY_POSITION_AUTO    = 0, ///< Automatic center positioning.
+	MTY_POSITION_FIXED   = 1, ///< Position using pixel values.
+	MTY_POSITION_MAKE_32 = INT32_MAX,
+} MTY_Position;
+
 /// @brief Description of a render operation.
 typedef struct {
 	MTY_ColorFormat format; ///< The color format of a raw image.
 	MTY_Rotation rotation;  ///< Rotation applied to the image.
 	MTY_Filter filter;      ///< Filter applied to the image.
 	MTY_Effect effect;      ///< Effect applied to the image.
+	MTY_Position type;      ///< Type of positioning configuration.
+	int32_t imageX;         ///< The horizontal position in pixels of the image.
+	int32_t imageY;         ///< The vertical position in pixels of the image.
 	uint32_t imageWidth;    ///< The width in pixels of the image.
 	uint32_t imageHeight;   ///< The height in pixels of the image.
 	uint32_t cropWidth;     ///< Desired crop width of the image from the top left corner.
 	uint32_t cropHeight;    ///< Desired crop height of the image from the top left corner.
 	uint32_t viewWidth;     ///< The width of the viewport.
 	uint32_t viewHeight;    ///< The height of the viewport.
+	uint32_t displayWidth;  ///< The current width of the window.
+	uint32_t displayHeight; ///< The current height of the window.
 	float aspectRatio;      ///< Desired aspect ratio of the image. The renderer will letterbox
 	                        ///<   the image to maintain the specified aspect ratio.
 	float scale;            ///< Multiplier applied to the dimensions of the image, producing an

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3613,6 +3613,12 @@ MTY_ZoomGetCursorX(MTY_Zoom *ctx);
 MTY_EXPORT int32_t 
 MTY_ZoomGetCursorY(MTY_Zoom *ctx);
 
+/// @brief Check whether a scaling gesture is in progress or not.
+/// @param ctx The MTY_Zoom.
+/// @returns True when scaling, otherwise false.
+MTY_EXPORT bool 
+MTY_ZoomIsScaling(MTY_Zoom *ctx);
+
 /// @brief Set whether a scaling gesture is in progress or not.
 /// @details Scaling status must be set to tell the context all values must be computed.
 ///   A disabled state is useful when preparing the context before actually scaling.
@@ -3621,11 +3627,19 @@ MTY_ZoomGetCursorY(MTY_Zoom *ctx);
 MTY_EXPORT void 
 MTY_ZoomSetScaling(MTY_Zoom *ctx, bool scaling);
 
-/// @brief Check whether a scaling gesture is in progress or not.
+/// @brief Check whether the context treats data as relative inputs or not.
 /// @param ctx The MTY_Zoom.
-/// @returns True when scaling, otherwise false.
+/// @returns True when relative, otherwise false.
 MTY_EXPORT bool 
-MTY_ZoomIsScaling(MTY_Zoom *ctx);
+MTY_ZoomIsRelative(MTY_Zoom *ctx);
+
+/// @brief Set whether the context treats data as relative inputs or not.
+/// @details In relative mode, transform functions return a scaled version of the provided
+///   relative coordinates (e.g. 1 will be tranformed to 0.5 if the current scale factor is 2).
+/// @param ctx The MTY_Zoom.
+/// @param scaling True when relative, otherwise false.
+MTY_EXPORT void 
+MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative);
 
 /// @brief Set the current context mode.
 /// @details Set the behavior the context must adopt when processing data:
@@ -3641,7 +3655,7 @@ MTY_ZoomSetMode(MTY_Zoom *ctx, MTY_InputMode mode);
 
 /// @brief Check if the context recommends to show a cursor.
 /// @details Currently, the context will recommend the show a cursor when the mode is
-///   MTY_INPUT_MODE_TRACKPAD, and to hide it otherwise.
+///   MTY_INPUT_MODE_TRACKPAD and the context is not relative, and to hide it otherwise.
 /// @param ctx The MTY_Zoom.
 /// @returns True is the cursor should be shown, false otherwise.
 MTY_EXPORT bool 

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3695,6 +3695,13 @@ typedef struct MTY_Cursor MTY_Cursor;
 MTY_EXPORT MTY_Cursor *
 MTY_CursorCreate(MTY_App *app);
 
+/// @brief Enable or disable cursor drawing.
+/// @details When disabled, MTY_CursorDraw() has not effect.
+/// @param ctx The MTY_Cursor.
+/// @param enable True to draw the cursor, false otherwise.
+MTY_EXPORT void
+MTY_CursorEnable(MTY_Cursor *ctx, bool enable);
+
 /// @brief Set the hotspot coordinates of the image
 /// @param ctx The MTY_Cursor.
 /// @param hotX The cursor's horizontal hotspot position.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3561,6 +3561,16 @@ MTY_ZoomFeed(MTY_Zoom *ctx, float scaleFactor, float focusX, float focusY);
 MTY_EXPORT void 
 MTY_ZoomResizeWindow(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight);
 
+/// @brief Set the scale limits of the context.
+/// @details This must be called before the first call to MTY_ZoomProcess(). If not, the
+///   change will only have effect after the next context reset, occuring after a window
+///   or image resize. By default, the minimum is 1 (100%) and the maximum is 4 (400%).
+/// @param ctx The MTY_Zoom.
+/// @param min The minimum scaling factor.
+/// @param max The maximum scaling factor.
+MTY_EXPORT void 
+MTY_ZoomSetLimits(MTY_Zoom *ctx, float min, float max);
+
 /// @brief Tranform an absolute X position to one relative to the zoomed area.
 /// @param ctx The MTY_Zoom.
 /// @param value The absolute X position.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3531,21 +3531,21 @@ MTY_GetVersion(void);
 typedef struct MTY_Zoom MTY_Zoom;
 
 /// @brief Create a scaling context.
-/// @param windowWidth The window width.
-/// @param windowHeight The window height.
 /// @returns The newly created scaling context.
 MTY_EXPORT MTY_Zoom *
-MTY_ZoomCreate(uint32_t windowWidth, uint32_t windowHeight);
+MTY_ZoomCreate();
 
 /// @brief Update the context with the image size.
 /// @details Process all the data accumulated by MTY_ZoomFeed() to produce
 ///   usable scaling factor and image coordinates. This method also resets
 ///   this accumulation.
 /// @param ctx The MTY_Zoom.
+/// @param window_w The window width.
+/// @param window_h The window height.
 /// @param imageWidth The image width.
 /// @param imageHeight The image height.
 MTY_EXPORT void 
-MTY_ZoomProcess(MTY_Zoom *ctx, uint32_t imageWidth, uint32_t imageHeight);
+MTY_ZoomProcess(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight, uint32_t imageWidth, uint32_t imageHeight);
 
 /// @brief Apply a scaling data to the context.
 /// @details Update the context with newly acquired scaling gesture data.
@@ -3568,34 +3568,6 @@ MTY_ZoomFeed(MTY_Zoom *ctx, float scaleFactor, float focusX, float focusY);
 /// @param start Defines the start of a new move gesture.
 MTY_EXPORT void
 MTY_ZoomMove(MTY_Zoom *ctx, int32_t x, int32_t y, bool start);
-
-/// @brief Set the current window size and reset the context.
-/// @details This is required by the context to know how to correctly scale the image.
-///   This should be called each time the window is resized.
-/// @param ctx The MTY_Zoom.
-/// @param window_w The window width.
-/// @param window_h The window height.
-MTY_EXPORT void 
-MTY_ZoomResizeWindow(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight);
-
-/// @brief Set the scale limits of the context.
-/// @details This must be called before the first call to MTY_ZoomProcess(). If not, the
-///   change will only have effect after the next context reset, occuring after a window
-///   or image resize. By default, the minimum is 1 (100%) and the maximum is 4 (400%).
-/// @param ctx The MTY_Zoom.
-/// @param min The minimum scaling factor.
-/// @param max The maximum scaling factor.
-MTY_EXPORT void 
-MTY_ZoomSetLimits(MTY_Zoom *ctx, float min, float max);
-
-/// @brief Sets whether the context is in relative mode or not.
-/// @details In absolute mode, the zoomed area does not move and the cursor if positioned
-///   within this area. In relative mode, the cursor is moved relatively to its previous 
-///   position and the zoomed area is panned if the cursor goes out.
-/// @param ctx The MTY_Zoom.
-/// @param relative Whether the context is in relative mode or not.
-MTY_EXPORT void 
-MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative);
 
 /// @brief Tranform an absolute X position to one relative to the zoomed area.
 /// @param ctx The MTY_Zoom.
@@ -3629,6 +3601,18 @@ MTY_ZoomGetImageX(MTY_Zoom *ctx);
 MTY_EXPORT int32_t 
 MTY_ZoomGetImageY(MTY_Zoom *ctx);
 
+/// @brief Get the current horizontal position of the cursor. 
+/// @param ctx The MTY_Zoom.
+/// @returns The horizontal position, in screen coordinates.
+MTY_EXPORT int32_t 
+MTY_ZoomGetCursorX(MTY_Zoom *ctx);
+
+/// @brief Get the current vertical position of the cursor.
+/// @param ctx The MTY_Zoom.
+/// @returns The vertical position, in screen coordinates.
+MTY_EXPORT int32_t 
+MTY_ZoomGetCursorY(MTY_Zoom *ctx);
+
 /// @brief Set whether a scaling gesture is in progress or not.
 /// @details Scaling status must be set to tell the context all values must be computed.
 ///   A disabled state is useful when preparing the context before actually scaling.
@@ -3642,6 +3626,31 @@ MTY_ZoomSetScaling(MTY_Zoom *ctx, bool scaling);
 /// @returns True when scaling, otherwise false.
 MTY_EXPORT bool 
 MTY_ZoomIsScaling(MTY_Zoom *ctx);
+
+/// @brief Sets whether the context is in relative mode or not.
+/// @details In absolute mode, the zoomed area does not move and the cursor if positioned
+///   within this area. In relative mode, the cursor is moved relatively to its previous 
+///   position and the zoomed area is panned if the cursor goes out.
+/// @param ctx The MTY_Zoom.
+/// @param relative Whether the context is in relative mode or not.
+MTY_EXPORT void 
+MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative);
+
+/// @brief Return whether a the context is in relative mode or not.
+/// @param ctx The MTY_Zoom.
+/// @returns True when in relative mode, otherwise false.
+MTY_EXPORT bool 
+MTY_ZoomIsRelative(MTY_Zoom *ctx);
+
+/// @brief Set the scale limits of the context.
+/// @details This must be called before the first call to MTY_ZoomProcess(). If not, the
+///   change will only have effect after the next context reset, occuring after a window
+///   or image resize. By default, the minimum is 1 (100%) and the maximum is 4 (400%).
+/// @param ctx The MTY_Zoom.
+/// @param min The minimum scaling factor.
+/// @param max The maximum scaling factor.
+MTY_EXPORT void 
+MTY_ZoomSetLimits(MTY_Zoom *ctx, float min, float max);
 
 /// @brief Destroy the scaling context.
 /// @param ctx The MTY_Zoom.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -635,6 +635,7 @@ typedef enum {
 
 typedef enum {
 	MTY_MOTION_FLAG_START    = 0x01, ///< Motion event has started.
+	MTY_MOTION_FLAG_TOUCH    = 0x02, ///< Motion event comes from a touch event.
 	MTY_MOTION_FLAG_MAKE_32  = INT32_MAX,
 } MTY_MotionFlag;
 

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -128,6 +128,7 @@ typedef struct {
 	float scale;            ///< Multiplier applied to the dimensions of the image, producing an
 	                        ///<   minimized or magnified image. This can be set to 0
 	                        ///<   if unnecessary.
+	bool clear;             ///< Should clear the window before drawing the quad.
 } MTY_RenderDesc;
 
 /// @brief A point with an `x` and `y` coordinate.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3501,6 +3501,99 @@ MTY_EXPORT uint32_t
 MTY_GetVersion(void);
 
 
+//- #module Zoom
+//- #mbrief Image scaling and positioning helper.
+
+typedef struct MTY_Zoom MTY_Zoom;
+
+/// @brief Create a scaling context.
+/// @param windowWidth The window width.
+/// @param windowHeight The window height.
+/// @returns The newly created scaling context.
+MTY_EXPORT MTY_Zoom *
+MTY_ZoomCreate(uint32_t windowWidth, uint32_t windowHeight);
+
+/// @brief Update the context with the image size.
+/// @details Process all the data accumulated by MTY_ZoomFeed() to produce
+///   usable scaling factor and image coordinates. This method also resets
+///   this accumulation.
+/// @param ctx The MTY_Zoom.
+/// @param imageWidth The image width.
+/// @param imageHeight The image height.
+MTY_EXPORT void 
+MTY_ZoomProcess(MTY_Zoom *ctx, uint32_t imageWidth, uint32_t imageHeight);
+
+/// @brief Apply a scaling data to the context.
+/// @details Update the context with newly acquired scaling gesture data.
+///   This method accumulate new values when scaling is enabled, and overwrite them 
+///   when scaling is disabled.
+/// @param ctx The MTY_Zoom.
+/// @param scaleFactor The new relative scale factor.
+/// @param focusX The new horizontal coordinate of the focal point.
+/// @param focusY The new vertical coordinate of the focal point.
+MTY_EXPORT void 
+MTY_ZoomFeed(MTY_Zoom *ctx, float scaleFactor, float focusX, float focusY);
+
+/// @brief Set the current window size and reset the context.
+/// @details This is required by the context to know how to correctly scale the image.
+///   This should be called each time the window is resized.
+/// @param ctx The MTY_Zoom.
+/// @param window_w The window width.
+/// @param window_h The window height.
+MTY_EXPORT void 
+MTY_ZoomResizeWindow(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight);
+
+/// @brief Tranform an absolute X position to one relative to the zoomed area.
+/// @param ctx The MTY_Zoom.
+/// @param value The absolute X position.
+/// @returns The zoom-relative X position.
+MTY_EXPORT int32_t 
+MTY_ZoomTranformX(MTY_Zoom *ctx, int32_t value);
+
+/// @brief Tranform an absolute Y position to one relative to the zoomed area.
+/// @param ctx The MTY_Zoom.
+/// @param value The absolute Y position.
+/// @returns The zoom-relative Y position.
+MTY_EXPORT int32_t 
+MTY_ZoomTranformY(MTY_Zoom *ctx, int32_t value);
+
+/// @brief Get the most recently computed scale value.
+/// @param ctx The MTY_Zoom.
+/// @returns The computed scale value.
+MTY_EXPORT float 
+MTY_ZoomGetScale(MTY_Zoom *ctx);
+
+/// @brief Get the most recently computed horizontal position of the image. 
+/// @param ctx The MTY_Zoom.
+/// @returns The computed horizontal position.
+MTY_EXPORT int32_t 
+MTY_ZoomGetImageX(MTY_Zoom *ctx);
+
+/// @brief Get the most recently computed vertical position of the image.
+/// @param ctx The MTY_Zoom.
+/// @returns The computed vertical position.
+MTY_EXPORT int32_t 
+MTY_ZoomGetImageY(MTY_Zoom *ctx);
+
+/// @brief Set whether a scaling gesture is in progress or not.
+/// @details Scaling status must be set to tell the context all values must be computed.
+///   A disabled state is useful when preparing the context before actually scaling.
+/// @param ctx The MTY_Zoom.
+/// @param scaling True when scaling, otherwise false.
+MTY_EXPORT void 
+MTY_ZoomSetScaling(MTY_Zoom *ctx, bool scaling);
+
+/// @brief Return whether a scaling gesture is in progress or not.
+/// @param ctx The MTY_Zoom.
+/// @returns True when scaling, otherwise false.
+MTY_EXPORT bool 
+MTY_ZoomIsScaling(MTY_Zoom *ctx);
+
+/// @brief Destroy the scaling context.
+/// @param ctx The MTY_Zoom.
+MTY_EXPORT void 
+MTY_ZoomDestroy(MTY_Zoom **ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -630,6 +630,11 @@ typedef enum {
 	MTY_CONTEXT_STATE_MAKE_32 = INT32_MAX,
 } MTY_ContextState;
 
+typedef enum {
+	MTY_MOTION_FLAG_START    = 0x01, ///< Motion event has started.
+	MTY_MOTION_FLAG_MAKE_32  = INT32_MAX,
+} MTY_MotionFlag;
+
 /// @brief State of a scaling gesture.
 typedef enum {
 	MTY_SCALE_STATE_ONGOING = 0, ///< The scaling gesture is in progress.
@@ -670,12 +675,13 @@ typedef struct {
 
 /// @brief Motion event.
 typedef struct {
-	int32_t x;     ///< If `relative` is true, the horizontal delta since the previous motion
-	               ///<   event, otherwise the horizontal position in the window's client area.
-	int32_t y;     ///< In `relative` is true, the vertical delta since the previous motion event,
-	               ///<   otherwise the vertical position in the window's client area.
-	bool relative; ///< The event is a relative motion event.
-	bool synth;    ///< The event was synthesized by libmatoya.
+	MTY_MotionFlag flags; ///< Additional motion event flags.
+	int32_t x;            ///< If `relative` is true, the horizontal delta since the previous motion
+	                      ///<   event, otherwise the horizontal position in the window's client area.
+	int32_t y;            ///< In `relative` is true, the vertical delta since the previous motion event,
+	                      ///<   otherwise the vertical position in the window's client area.
+	bool relative;        ///< The event is a relative motion event.
+	bool synth;           ///< The event was synthesized by libmatoya.
 } MTY_MotionEvent;
 
 /// @brief File drop event.
@@ -3552,6 +3558,17 @@ MTY_ZoomProcess(MTY_Zoom *ctx, uint32_t imageWidth, uint32_t imageHeight);
 MTY_EXPORT void 
 MTY_ZoomFeed(MTY_Zoom *ctx, float scaleFactor, float focusX, float focusY);
 
+/// @brief Notify the context of a cursor move.
+/// @details Calling this function allows to keep track of the cursor movement.
+///   This is required in relative mode, and optional in absolute mode. When a move
+///   starts, the coordinates are used as the new gesture origin.
+/// @param ctx The MTY_Zoom.
+/// @param x The new X position of the cursor.
+/// @param y The new Y position of the cursor.
+/// @param start Defines the start of a new move gesture.
+MTY_EXPORT void
+MTY_ZoomMove(MTY_Zoom *ctx, int32_t x, int32_t y, bool start);
+
 /// @brief Set the current window size and reset the context.
 /// @details This is required by the context to know how to correctly scale the image.
 ///   This should be called each time the window is resized.
@@ -3570,6 +3587,15 @@ MTY_ZoomResizeWindow(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight)
 /// @param max The maximum scaling factor.
 MTY_EXPORT void 
 MTY_ZoomSetLimits(MTY_Zoom *ctx, float min, float max);
+
+/// @brief Sets whether the context is in relative mode or not.
+/// @details In absolute mode, the zoomed area does not move and the cursor if positioned
+///   within this area. In relative mode, the cursor is moved relatively to its previous 
+///   position and the zoomed area is panned if the cursor goes out.
+/// @param ctx The MTY_Zoom.
+/// @param relative Whether the context is in relative mode or not.
+MTY_EXPORT void 
+MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative);
 
 /// @brief Tranform an absolute X position to one relative to the zoomed area.
 /// @param ctx The MTY_Zoom.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -129,6 +129,7 @@ typedef struct {
 	                        ///<   minimized or magnified image. This can be set to 0
 	                        ///<   if unnecessary.
 	bool clear;             ///< Should clear the window before drawing the quad.
+	bool blend;             ///< Should enable blending capability when drawing the quad.
 } MTY_RenderDesc;
 
 /// @brief A point with an `x` and `y` coordinate.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3654,11 +3654,17 @@ MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative);
 MTY_EXPORT void 
 MTY_ZoomSetMode(MTY_Zoom *ctx, MTY_InputMode mode);
 
+/// @brief Check if the cursor has moved since the previous call.
+/// @param ctx The MTY_Zoom.
+/// @returns True if the cursor has moved, false otherwise.
+MTY_EXPORT bool 
+MTY_ZoomHasMoved(MTY_Zoom *ctx);
+
 /// @brief Check if the context recommends to show a cursor.
 /// @details Currently, the context will recommend the show a cursor when the mode is
 ///   MTY_INPUT_MODE_TRACKPAD and the context is not relative, and to hide it otherwise.
 /// @param ctx The MTY_Zoom.
-/// @returns True is the cursor should be shown, false otherwise.
+/// @returns True if the cursor should be shown, false otherwise.
 MTY_EXPORT bool 
 MTY_ZoomShouldShowCursor(MTY_Zoom *ctx);
 

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -131,6 +131,7 @@ typedef struct {
 	                        ///<   if unnecessary.
 	bool clear;             ///< Should clear the window before drawing the quad.
 	bool blend;             ///< Should enable blending capability when drawing the quad.
+	                        ///<   Note: This is currently not supported in D3D12 and Metal.
 } MTY_RenderDesc;
 
 /// @brief A point with an `x` and `y` coordinate.
@@ -3544,8 +3545,8 @@ MTY_ZoomCreate();
 ///   This function has not effect in provided metrics are the same as the ones
 ///   provided to the previous call of MTY_ZoomUpdate().
 /// @param ctx The MTY_Zoom.
-/// @param window_w The window width.
-/// @param window_h The window height.
+/// @param windowWidth The window width.
+/// @param windowHeight The window height.
 /// @param imageWidth The image width.
 /// @param imageHeight The image height.
 MTY_EXPORT void 

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3648,6 +3648,57 @@ MTY_ZoomIsScaling(MTY_Zoom *ctx);
 MTY_EXPORT void 
 MTY_ZoomDestroy(MTY_Zoom **ctx);
 
+
+//- #module Cursor
+//- #mbrief Cursor manipulation and display helper.
+
+typedef struct MTY_Cursor MTY_Cursor;
+
+/// @brief Create a cursor context.
+/// @param ctx The MTY_Cursor.
+/// @returns The newly created cursor context.
+MTY_EXPORT MTY_Cursor *
+MTY_CursorCreate(MTY_App *app);
+
+/// @brief Set the hotspot coordinates of the image
+/// @param ctx The MTY_Cursor.
+/// @param hotX The cursor's horizontal hotspot position.
+/// @param hotY The cursor's vertical hotspot position.
+MTY_EXPORT void
+MTY_CursorSetHotspot(MTY_Cursor *ctx, uint16_t hotX, uint16_t hotY);
+
+/// @brief Decompress and set the cursor image.
+/// @param ctx The MTY_Cursor.
+/// @param data The compressed image data.
+/// @param size The size of the image data.
+MTY_EXPORT void
+MTY_CursorSetImage(MTY_Cursor *ctx, const void *data, size_t size);
+
+/// @brief Move the cursor to the specified position.
+/// @param ctx The MTY_Cursor.
+/// @param x The new cursor's horizontal position.
+/// @param y The new cursor's vertical position.
+/// @param scale The scaling factor to apply on the image.
+MTY_EXPORT void
+MTY_CursorMove(MTY_Cursor *ctx, int32_t x, int32_t y, float scale);
+
+/// @brief Move the cursor based on the current MTY_Zoom state.
+/// @param ctx The MTY_Cursor.
+/// @param zoom The MTY_Zoom.
+MTY_EXPORT void
+MTY_CursorMoveFromZoom(MTY_Cursor *ctx, MTY_Zoom *zoom);
+
+/// @brief Draw the cursor on the specified window
+/// @param ctx The MTY_Cursor.
+/// @param window The target window.
+MTY_EXPORT void
+MTY_CursorDraw(MTY_Cursor *ctx, MTY_Window window);
+
+/// @brief Destroy the cursor context.
+/// @param ctx The MTY_Cursor.
+MTY_EXPORT void
+MTY_CursorDestroy(MTY_Cursor **ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/unix/apple/gfx/metal.m
+++ b/src/unix/apple/gfx/metal.m
@@ -157,11 +157,18 @@ static void metal_reload_textures(struct metal *ctx, id<MTLDevice> device, const
 {
 	switch (desc->format) {
 		case MTY_COLOR_FORMAT_BGRA:
+		case MTY_COLOR_FORMAT_RGBA:
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
 		case MTY_COLOR_FORMAT_BGRA5551: {
-			MTLPixelFormat format = MTLPixelFormatBGRA8Unorm;
-			uint8_t bpp = (desc->format == MTY_COLOR_FORMAT_BGRA || desc->format == MTY_COLOR_FORMAT_AYUV) ? 4 : 2;
+			MTLPixelFormat format = desc->format == MTY_COLOR_FORMAT_RGBA
+				? MTLPixelFormatRGBA8Unorm
+				: MTLPixelFormatBGRA8Unorm;
+			uint8_t bpp =
+				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
+				sizeof(uint16_t);
 
 			// 16-bit packed pixel formats were not available until Big Sur
 			if (bpp == 2) {

--- a/src/unix/apple/gfx/metal.m
+++ b/src/unix/apple/gfx/metal.m
@@ -253,8 +253,10 @@ bool mty_metal_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 	// Begin render pass
 	MTLRenderPassDescriptor *rpd = [MTLRenderPassDescriptor new];
 	rpd.colorAttachments[0].texture = _dest;
-	rpd.colorAttachments[0].clearColor = MTLClearColorMake(0.0, 0.0, 0.0, 1.0);
-	rpd.colorAttachments[0].loadAction = MTLLoadActionClear;
+	if (desc->clear) {
+		rpd.colorAttachments[0].clearColor = MTLClearColorMake(0.0, 0.0, 0.0, 1.0);
+		rpd.colorAttachments[0].loadAction = MTLLoadActionClear;
+	}
 	rpd.colorAttachments[0].storeAction = MTLStoreActionStore;
 
 	id<MTLCommandBuffer> cb = [cq commandBuffer];

--- a/src/unix/apple/gfx/metal.m
+++ b/src/unix/apple/gfx/metal.m
@@ -265,9 +265,7 @@ bool mty_metal_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	float vpx, vpy, vpw, vph;
-	mty_viewport(desc->rotation, desc->cropWidth, desc->cropHeight,
-		desc->viewWidth, desc->viewHeight, desc->aspectRatio, desc->scale,
-		&vpx, &vpy, &vpw, &vph);
+	mty_viewport(desc, &vpx, &vpy, &vpw, &vph, false);
 
 	MTLViewport vp = {0};
 	vp.originX = vpx;

--- a/src/unix/linux/android/Matoya.java
+++ b/src/unix/linux/android/Matoya.java
@@ -535,6 +535,23 @@ public class Matoya extends SurfaceView implements
 		});
 	}
 
+	public void setRelativeMouse(boolean _relative) {
+		final Matoya self = this;
+		final boolean relative = _relative;
+
+		this.activity.runOnUiThread(new Runnable() {
+			@Override
+			public void run() {
+				if (relative) {
+					self.requestPointerCapture();
+
+				} else {
+					self.releasePointerCapture();
+				}
+			}
+		});
+	}
+
 
 	// Misc
 

--- a/src/unix/linux/android/Matoya.java
+++ b/src/unix/linux/android/Matoya.java
@@ -117,6 +117,8 @@ public class Matoya extends SurfaceView implements
 		this.getHolder().addCallback(this);
 		this.detector.setOnDoubleTapListener(this);
 		this.detector.setContextClickListener(this);
+		this.sdetector.setQuickScaleEnabled(false);
+		this.sdetector.setStylusScaleEnabled(false);
 		this.setFocusableInTouchMode(true);
 		this.setFocusable(true);
 		this.requestFocus();

--- a/src/unix/linux/android/Matoya.java
+++ b/src/unix/linux/android/Matoya.java
@@ -74,6 +74,7 @@ public class Matoya extends SurfaceView implements
 	native void app_mouse_motion(boolean relative, float x, float y);
 	native void app_mouse_button(boolean pressed, int button, float x, float y);
 	native void app_generic_scroll(float x, float y);
+	native void app_scale(float scaleFactor, float focusX, float focusY, boolean begin, boolean end);
 	native void app_button(int deviceId, boolean pressed, int code);
 	native void app_axis(int deviceId, float hatX, float hatY, float lX, float lY, float rX, float rY,
 		float lT, float rT, float lTalt, float rTalt);
@@ -373,18 +374,28 @@ public class Matoya extends SurfaceView implements
 		return this.onGenericMotionEvent(event);
 	}
 
+	private void processScale(ScaleGestureDetector sdetector, boolean start, boolean stop) {
+		float focusX = sdetector.getFocusX();
+		float focusY = sdetector.getFocusY();
+
+		app_scale(sdetector.getScaleFactor(), focusX, focusY, start, stop);
+	}
+
 	@Override
-	public boolean onScale(ScaleGestureDetector detector) {
+	public boolean onScale(ScaleGestureDetector sdetector) {
+		processScale(sdetector, false, false);
 		return true;
 	}
 
 	@Override
 	public boolean onScaleBegin(ScaleGestureDetector sdetector) {
+		processScale(sdetector, true, false);
 		return true;
 	}
 
 	@Override
 	public void onScaleEnd(ScaleGestureDetector sdetector) {
+		processScale(sdetector, false, true);
 	}
 
 

--- a/src/unix/linux/android/Matoya.java
+++ b/src/unix/linux/android/Matoya.java
@@ -535,27 +535,6 @@ public class Matoya extends SurfaceView implements
 		});
 	}
 
-	public void setRelativeMouse(boolean _relative) {
-		final Matoya self = this;
-		final boolean relative = _relative;
-
-		this.activity.runOnUiThread(new Runnable() {
-			@Override
-			public void run() {
-				if (relative) {
-					self.requestPointerCapture();
-
-				} else {
-					self.releasePointerCapture();
-				}
-			}
-		});
-	}
-
-	public boolean getRelativeMouse() {
-		return this.hasPointerCapture();
-	}
-
 
 	// Misc
 

--- a/src/unix/linux/android/Matoya.java
+++ b/src/unix/linux/android/Matoya.java
@@ -283,6 +283,10 @@ public class Matoya extends SurfaceView implements
 		if (isMouseEvent(event))
 			return;
 
+		MotionEvent cancel = MotionEvent.obtain(event);
+		cancel.setAction(MotionEvent.ACTION_CANCEL);
+		this.detector.onTouchEvent(cancel);
+
 		if (app_long_press(event.getX(0), event.getY(0)))
 			this.vibrator.vibrate(10);
 	}

--- a/src/unix/linux/android/Matoya.java
+++ b/src/unix/linux/android/Matoya.java
@@ -235,6 +235,9 @@ public class Matoya extends SurfaceView implements
 		return keyEvent(keyCode, event, false);
 	}
 
+	int previousFingers = 0;
+	boolean isNewGesture = false;
+
 	@Override
 	public boolean onTouchEvent(MotionEvent event) {
 		// Mouse motion while buttons are held down fire here
@@ -243,6 +246,13 @@ public class Matoya extends SurfaceView implements
 				app_mouse_motion(false, event.getX(0), event.getY(0));
 
 		} else {
+			int currentFingers = event.getPointerCount();
+			if (event.getAction() == MotionEvent.ACTION_UP)
+				currentFingers--;
+			if (previousFingers != currentFingers)
+				isNewGesture = true;
+			previousFingers = currentFingers;
+
 			this.detector.onTouchEvent(event);
 			this.sdetector.onTouchEvent(event);
 
@@ -252,14 +262,10 @@ public class Matoya extends SurfaceView implements
 		return true;
 	}
 
-	boolean gestureStarted = false;
-
 	@Override
 	public boolean onDown(MotionEvent event) {
 		if (isMouseEvent(event))
 			return false;
-
-		gestureStarted = true;
 
 		this.scroller.forceFinished(true);
 		return true;
@@ -297,8 +303,8 @@ public class Matoya extends SurfaceView implements
 			return false;
 
 		this.scroller.forceFinished(true);
-		app_scroll(event2.getX(0), event2.getY(0), distanceX, distanceY, event2.getPointerCount(), gestureStarted);
-		gestureStarted = false;
+		app_scroll(event2.getX(0), event2.getY(0), distanceX, distanceY, event2.getPointerCount(), isNewGesture);
+		isNewGesture = false;
 
 		return true;
 	}

--- a/src/unix/linux/android/Matoya.java
+++ b/src/unix/linux/android/Matoya.java
@@ -55,7 +55,9 @@ public class Matoya extends SurfaceView implements
 	boolean hiddenCursor;
 	boolean defaultCursor;
 	boolean kbShowing;
+	boolean isNewGesture;
 	float displayDensity;
+	int touchingFingers;
 	int scrollY;
 
 	native void gfx_set_surface(Surface surface);
@@ -235,9 +237,6 @@ public class Matoya extends SurfaceView implements
 		return keyEvent(keyCode, event, false);
 	}
 
-	int previousFingers = 0;
-	boolean isNewGesture = false;
-
 	@Override
 	public boolean onTouchEvent(MotionEvent event) {
 		// Mouse motion while buttons are held down fire here
@@ -249,9 +248,9 @@ public class Matoya extends SurfaceView implements
 			int currentFingers = event.getPointerCount();
 			if (event.getAction() == MotionEvent.ACTION_UP)
 				currentFingers--;
-			if (previousFingers != currentFingers)
+			if (touchingFingers != currentFingers)
 				isNewGesture = true;
-			previousFingers = currentFingers;
+			touchingFingers = currentFingers;
 
 			this.detector.onTouchEvent(event);
 			this.sdetector.onTouchEvent(event);

--- a/src/unix/linux/android/Matoya.java
+++ b/src/unix/linux/android/Matoya.java
@@ -69,7 +69,7 @@ public class Matoya extends SurfaceView implements
 	native void app_resize(int width, int height);
 	native void app_unplug(int deviceId);
 	native void app_single_tap_up(float x, float y);
-	native void app_scroll(float absX, float absY, float x, float y, int fingers);
+	native void app_scroll(float absX, float absY, float x, float y, int fingers, boolean start);
 	native void app_check_scroller(boolean check);
 	native void app_mouse_motion(boolean relative, float x, float y);
 	native void app_mouse_button(boolean pressed, int button, float x, float y);
@@ -250,10 +250,14 @@ public class Matoya extends SurfaceView implements
 		return true;
 	}
 
+	boolean gestureStarted = false;
+
 	@Override
 	public boolean onDown(MotionEvent event) {
 		if (isMouseEvent(event))
 			return false;
+
+		gestureStarted = true;
 
 		this.scroller.forceFinished(true);
 		return true;
@@ -287,7 +291,9 @@ public class Matoya extends SurfaceView implements
 			return false;
 
 		this.scroller.forceFinished(true);
-		app_scroll(event2.getX(0), event2.getY(0), distanceX, distanceY, event2.getPointerCount());
+		app_scroll(event2.getX(0), event2.getY(0), distanceX, distanceY, event2.getPointerCount(), gestureStarted);
+		gestureStarted = false;
+
 		return true;
 	}
 
@@ -570,7 +576,7 @@ public class Matoya extends SurfaceView implements
 			int diff = this.scrollY - currY;
 
 			if (diff != 0)
-				app_scroll(-1.0f, -1.0f, 0.0f, diff, 1);
+				app_scroll(-1.0f, -1.0f, 0.0f, diff, 1, false);
 
 			this.scrollY = currY;
 

--- a/src/unix/linux/android/app.c
+++ b/src/unix/linux/android/app.c
@@ -400,14 +400,14 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scroll(JNIEnv *env, job
 		MTY_Event evt = {0};
 
 		// Negative init values mean "don't move the cursor"
-		if (abs_x > 0.0f || abs_y > 0.0f) {
+		// Only move on the first event to prevent the cursor from going out of range
+		if (start && (abs_x > 0.0f || abs_y > 0.0f)) {
 			evt.type = MTY_EVENT_MOTION;
 			evt.motion.relative = CTX.relative;
 			evt.motion.x = CTX.relative ? -lrint(x) : lrint(abs_x);
 			evt.motion.y = CTX.relative ? -lrint(y) : lrint(abs_y);
 			evt.motion.flags |= MTY_MOTION_FLAG_TOUCH;
-			if (start)
-				evt.motion.flags |= MTY_MOTION_FLAG_START;
+			evt.motion.flags |= MTY_MOTION_FLAG_START;
 			app_push_event(&CTX, &evt);
 		}
 

--- a/src/unix/linux/android/app.c
+++ b/src/unix/linux/android/app.c
@@ -401,8 +401,6 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scroll(JNIEnv *env, job
 {
 	CTX.should_detach = false;
 
-	app_cancel_long_button(&CTX, lrint(abs_x), lrint(abs_y));
-
 	// Single finger scrolling in touchscreen mode OR two finger scrolling in
 	// trackpad mode moves to the touch location and produces a scroll event
 	if (CTX.input == MTY_INPUT_MODE_TOUCHSCREEN ||

--- a/src/unix/linux/android/app.c
+++ b/src/unix/linux/android/app.c
@@ -922,6 +922,11 @@ void MTY_AppSetInputMode(MTY_App *ctx, MTY_InputMode mode)
 
 MTY_Window MTY_WindowCreate(MTY_App *app, const MTY_WindowDesc *desc)
 {
+	if (desc->api != MTY_GFX_NONE && desc->api != MTY_GFX_GL)
+		return -1;
+	
+	MTY_WindowSetGFX(app, 0, desc->api, desc->vsync);
+
 	return 0;
 }
 

--- a/src/unix/linux/android/app.c
+++ b/src/unix/linux/android/app.c
@@ -397,7 +397,7 @@ JNIEXPORT jboolean JNICALL Java_group_matoya_lib_Matoya_app_1long_1press(JNIEnv 
 }
 
 JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scroll(JNIEnv *env, jobject obj,
-	jfloat abs_x, jfloat abs_y, jfloat x, jfloat y, jint fingers)
+	jfloat abs_x, jfloat abs_y, jfloat x, jfloat y, jint fingers, jboolean start)
 {
 	CTX.should_detach = false;
 
@@ -415,6 +415,8 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scroll(JNIEnv *env, job
 			evt.type = MTY_EVENT_MOTION;
 			evt.motion.x = lrint(abs_x);
 			evt.motion.y = lrint(abs_y);
+			if (start)
+				evt.motion.flags |= MTY_MOTION_FLAG_START;
 			app_push_event(&CTX, &evt);
 		}
 
@@ -430,6 +432,8 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scroll(JNIEnv *env, job
 		evt.type = MTY_EVENT_MOTION;
 		evt.motion.x = lrint(abs_x);
 		evt.motion.y = lrint(abs_y);
+		if (start)
+			evt.motion.flags |= MTY_MOTION_FLAG_START;
 		app_push_event(&CTX, &evt);
 	}
 }

--- a/src/unix/linux/android/app.c
+++ b/src/unix/linux/android/app.c
@@ -464,6 +464,23 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1generic_1scroll(JNIEnv 
 	app_push_event(&CTX, &evt);
 }
 
+JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scale(JNIEnv *env, jobject obj,
+	jfloat scaleFactor, jfloat focus_x, jfloat focus_y, jboolean start, jboolean stop)
+{
+	CTX.should_detach = true;
+
+	MTY_Event evt = {0};
+	evt.type = MTY_EVENT_SCALE;
+	evt.scale.factor = scaleFactor;
+	evt.scale.focusX = focus_x;
+	evt.scale.focusY = focus_y;
+	evt.scale.state = 
+		start ? MTY_SCALE_STATE_START :
+		stop  ? MTY_SCALE_STATE_STOP  :
+		MTY_SCALE_STATE_ONGOING;
+	app_push_event(&CTX, &evt);
+}
+
 JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1mouse_1button(JNIEnv *env, jobject obj,
 	jboolean pressed, jint button, jfloat x, jfloat y)
 {

--- a/src/unix/linux/android/app.c
+++ b/src/unix/linux/android/app.c
@@ -324,17 +324,6 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1unhandled_1touch(JNIEnv
 
 	if (CTX.input != MTY_INPUT_MODE_TOUCHSCREEN) {
 		switch (action) {
-			case AMOTION_EVENT_ACTION_MOVE:
-				// While a long press is in effect, move events get reported here
-				// They do NOT come through in the onScroll gesture handler
-				if (CTX.long_button != MTY_BUTTON_NONE) {
-					MTY_Event evt = {0};
-					evt.type = MTY_EVENT_MOTION;
-					evt.motion.x = lrint(x);
-					evt.motion.y = lrint(y);
-					app_push_event(&CTX, &evt);
-				}
-				break;
 			case AMOTION_EVENT_ACTION_POINTER_DOWN:
 				// Taps with two fingers need to be handled manually
 				// They are not detected by the gesture recognizer
@@ -400,6 +389,7 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scroll(JNIEnv *env, job
 	jfloat abs_x, jfloat abs_y, jfloat x, jfloat y, jint fingers, jboolean start)
 {
 	CTX.should_detach = false;
+	CTX.double_tap = false;
 
 	// Single finger scrolling in touchscreen mode OR two finger scrolling in
 	// trackpad mode moves to the touch location and produces a scroll event
@@ -470,6 +460,7 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scale(JNIEnv *env, jobj
 	jfloat scaleFactor, jfloat focus_x, jfloat focus_y, jboolean start, jboolean stop)
 {
 	CTX.should_detach = true;
+	CTX.double_tap = false;
 
 	MTY_Event evt = {0};
 	evt.type = MTY_EVENT_SCALE;

--- a/src/unix/linux/android/app.c
+++ b/src/unix/linux/android/app.c
@@ -41,6 +41,7 @@ static struct MTY_App {
 	bool check_scroller;
 	bool log_thread_running;
 	bool should_detach;
+	bool relative;
 
 	MTY_GFX api;
 	struct gfx_ctx *gfx_ctx;
@@ -401,8 +402,9 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scroll(JNIEnv *env, job
 		// Negative init values mean "don't move the cursor"
 		if (abs_x > 0.0f || abs_y > 0.0f) {
 			evt.type = MTY_EVENT_MOTION;
-			evt.motion.x = lrint(abs_x);
-			evt.motion.y = lrint(abs_y);
+			evt.motion.relative = CTX.relative;
+			evt.motion.x = CTX.relative ? -lrint(x) : lrint(abs_x);
+			evt.motion.y = CTX.relative ? -lrint(y) : lrint(abs_y);
 			if (start)
 				evt.motion.flags |= MTY_MOTION_FLAG_START;
 			app_push_event(&CTX, &evt);
@@ -418,8 +420,9 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scroll(JNIEnv *env, job
 	} else if (abs_x > 0.0f || abs_y > 0.0f) {
 		MTY_Event evt = {0};
 		evt.type = MTY_EVENT_MOTION;
-		evt.motion.x = lrint(abs_x);
-		evt.motion.y = lrint(abs_y);
+		evt.motion.relative = CTX.relative;
+		evt.motion.x = CTX.relative ? -lrint(x) : lrint(abs_x);
+		evt.motion.y = CTX.relative ? -lrint(y) : lrint(abs_y);
 		if (start)
 			evt.motion.flags |= MTY_MOTION_FLAG_START;
 		app_push_event(&CTX, &evt);
@@ -814,12 +817,12 @@ void MTY_AppGrabMouse(MTY_App *ctx, bool grab)
 
 bool MTY_AppGetRelativeMouse(MTY_App *ctx)
 {
-	return mty_jni_bool(MTY_GetJNIEnv(), ctx->obj, "getRelativeMouse", "()Z");
+	return ctx->relative;
 }
 
 void MTY_AppSetRelativeMouse(MTY_App *ctx, bool relative)
 {
-	mty_jni_void(MTY_GetJNIEnv(), ctx->obj, "setRelativeMouse", "(Z)V", relative);
+	ctx->relative = relative;
 }
 
 void MTY_AppSetPNGCursor(MTY_App *ctx, const void *image, size_t size, uint32_t hotX, uint32_t hotY)

--- a/src/unix/linux/android/app.c
+++ b/src/unix/linux/android/app.c
@@ -405,6 +405,7 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scroll(JNIEnv *env, job
 			evt.motion.relative = CTX.relative;
 			evt.motion.x = CTX.relative ? -lrint(x) : lrint(abs_x);
 			evt.motion.y = CTX.relative ? -lrint(y) : lrint(abs_y);
+			evt.motion.flags |= MTY_MOTION_FLAG_TOUCH;
 			if (start)
 				evt.motion.flags |= MTY_MOTION_FLAG_START;
 			app_push_event(&CTX, &evt);
@@ -423,6 +424,7 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scroll(JNIEnv *env, job
 		evt.motion.relative = CTX.relative;
 		evt.motion.x = CTX.relative ? -lrint(x) : lrint(abs_x);
 		evt.motion.y = CTX.relative ? -lrint(y) : lrint(abs_y);
+		evt.motion.flags |= MTY_MOTION_FLAG_TOUCH;
 		if (start)
 			evt.motion.flags |= MTY_MOTION_FLAG_START;
 		app_push_event(&CTX, &evt);

--- a/src/unix/linux/android/app.c
+++ b/src/unix/linux/android/app.c
@@ -824,6 +824,8 @@ bool MTY_AppGetRelativeMouse(MTY_App *ctx)
 
 void MTY_AppSetRelativeMouse(MTY_App *ctx, bool relative)
 {
+	mty_jni_void(MTY_GetJNIEnv(), ctx->obj, "setRelativeMouse", "(Z)V", relative);
+
 	ctx->relative = relative;
 }
 

--- a/src/windows/gfx/d3d11.c
+++ b/src/windows/gfx/d3d11.c
@@ -277,12 +277,20 @@ static HRESULT d3d11_reload_textures(struct d3d11 *ctx, ID3D11Device *device, ID
 {
 	switch (desc->format) {
 		case MTY_COLOR_FORMAT_BGRA:
+		case MTY_COLOR_FORMAT_RGBA:
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
 		case MTY_COLOR_FORMAT_BGRA5551: {
-			DXGI_FORMAT format = desc->format == MTY_COLOR_FORMAT_BGR565 ? DXGI_FORMAT_B5G6R5_UNORM :
-				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? DXGI_FORMAT_B5G5R5A1_UNORM : DXGI_FORMAT_B8G8R8A8_UNORM;
-			uint8_t bpp = (desc->format == MTY_COLOR_FORMAT_BGRA || desc->format == MTY_COLOR_FORMAT_AYUV) ? 4 : 2;
+			DXGI_FORMAT format =
+				desc->format == MTY_COLOR_FORMAT_BGR565   ? DXGI_FORMAT_B5G6R5_UNORM   :
+				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? DXGI_FORMAT_B5G5R5A1_UNORM :
+				desc->format == MTY_COLOR_FORMAT_RGBA     ? DXGI_FORMAT_R8G8B8A8_UNORM :
+				DXGI_FORMAT_B8G8R8A8_UNORM;
+			uint8_t bpp =
+				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
+				sizeof(uint16_t);
 
 			// BGRA
 			HRESULT e = d3d11_refresh_resource(&ctx->staging[0], device, format, desc->cropWidth, desc->cropHeight);

--- a/src/windows/gfx/d3d11.c
+++ b/src/windows/gfx/d3d11.c
@@ -364,9 +364,7 @@ bool mty_d3d11_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	D3D11_VIEWPORT vp = {0};
-	mty_viewport(desc->rotation, desc->cropWidth, desc->cropHeight,
-		desc->viewWidth, desc->viewHeight, desc->aspectRatio, desc->scale,
-		&vp.TopLeftX, &vp.TopLeftY, &vp.Width, &vp.Height);
+	mty_viewport(desc, &vp.TopLeftX, &vp.TopLeftY, &vp.Width, &vp.Height, false);
 
 	ID3D11DeviceContext_RSSetViewports(_context, 1, &vp);
 

--- a/src/windows/gfx/d3d11.c
+++ b/src/windows/gfx/d3d11.c
@@ -53,6 +53,7 @@ struct d3d11 {
 	ID3D11SamplerState *ss_nearest;
 	ID3D11SamplerState *ss_linear;
 	ID3D11RasterizerState *rs;
+	ID3D11BlendState *bs;
 	ID3D11DepthStencilState *dss;
 };
 
@@ -165,6 +166,22 @@ struct gfx *mty_d3d11_create(MTY_Device *device)
 	e = ID3D11Device_CreateRasterizerState(_device, &rdesc, &ctx->rs);
 	if (e != S_OK) {
 		MTY_Log("'ID3D11Device_CreateRasterizerState' failed with HRESULT 0x%X", e);
+		goto except;
+	}
+
+	D3D11_BLEND_DESC bdesc = {0};
+	bdesc.AlphaToCoverageEnable = false;
+	bdesc.RenderTarget[0].BlendEnable = true;
+	bdesc.RenderTarget[0].SrcBlend = D3D11_BLEND_SRC_ALPHA;
+	bdesc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
+	bdesc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
+	bdesc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
+	bdesc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
+	bdesc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
+	bdesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+	e = ID3D11Device_CreateBlendState(_device, &bdesc, &ctx->bs);
+	if (e != S_OK) {
+		MTY_Log("'ID3D11Device_CreateBlendState' failed with HRESULT 0x%X", e);
 		goto except;
 	}
 
@@ -410,7 +427,15 @@ bool mty_d3d11_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 	ID3D11DeviceContext_IASetIndexBuffer(_context, ctx->ib, DXGI_FORMAT_R32_UINT, 0);
 	ID3D11DeviceContext_IASetInputLayout(_context, ctx->il);
 	ID3D11DeviceContext_IASetPrimitiveTopology(_context, D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-	ID3D11DeviceContext_OMSetBlendState(_context, NULL, NULL, 0xFFFFFFFF);
+
+	if (desc->blend) {
+		const float blend_factor[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+		ID3D11DeviceContext_OMSetBlendState(_context, ctx->bs, blend_factor, 0xFFFFFFFF);
+
+	} else {
+		ID3D11DeviceContext_OMSetBlendState(_context, NULL, NULL, 0xFFFFFFFF);
+	}
+
 	ID3D11DeviceContext_OMSetDepthStencilState(_context, ctx->dss, 0);
 	ID3D11DeviceContext_RSSetState(_context, ctx->rs);
 
@@ -468,6 +493,9 @@ void mty_d3d11_destroy(struct gfx **gfx)
 
 	if (ctx->rs)
 		ID3D11RasterizerState_Release(ctx->rs);
+
+	if (ctx->bs)
+		ID3D11BlendState_Release(ctx->bs);
 
 	if (ctx->dss)
 		ID3D11DepthStencilState_Release(ctx->dss);

--- a/src/windows/gfx/d3d11.c
+++ b/src/windows/gfx/d3d11.c
@@ -387,8 +387,10 @@ bool mty_d3d11_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 		ID3D11DeviceContext_OMSetRenderTargets(_context, 1, &rtv, NULL);
 
-		FLOAT clear_color[4] = {0.0f, 0.0f, 0.0f, 1.0f};
-		ID3D11DeviceContext_ClearRenderTargetView(_context, rtv, clear_color);
+		if (desc->clear) {
+			FLOAT clear_color[4] = {0.0f, 0.0f, 0.0f, 1.0f};
+			ID3D11DeviceContext_ClearRenderTargetView(_context, rtv, clear_color);
+		}
 	}
 
 	// Vertex shader

--- a/src/windows/gfx/d3d12.c
+++ b/src/windows/gfx/d3d12.c
@@ -472,12 +472,20 @@ static HRESULT d3d12_reload_textures(struct d3d12 *ctx, ID3D12Device *device, ID
 {
 	switch (desc->format) {
 		case MTY_COLOR_FORMAT_BGRA:
+		case MTY_COLOR_FORMAT_RGBA:
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
 		case MTY_COLOR_FORMAT_BGRA5551: {
-			DXGI_FORMAT format = desc->format == MTY_COLOR_FORMAT_BGR565 ? DXGI_FORMAT_B5G6R5_UNORM :
-				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? DXGI_FORMAT_B5G5R5A1_UNORM : DXGI_FORMAT_B8G8R8A8_UNORM;
-			uint8_t bpp = (desc->format == MTY_COLOR_FORMAT_BGRA || desc->format == MTY_COLOR_FORMAT_AYUV) ? 4 : 2;
+			DXGI_FORMAT format =
+				desc->format == MTY_COLOR_FORMAT_BGR565   ? DXGI_FORMAT_B5G6R5_UNORM   :
+				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? DXGI_FORMAT_B5G5R5A1_UNORM :
+				desc->format == MTY_COLOR_FORMAT_RGBA     ? DXGI_FORMAT_R8G8B8A8_UNORM :
+				DXGI_FORMAT_B8G8R8A8_UNORM;
+			uint8_t bpp =
+				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
+				sizeof(uint16_t);
 
 			// BGRA
 			HRESULT e = d3d12_refresh_resource(&ctx->staging[0], device, format, desc->cropWidth, desc->cropHeight, bpp);

--- a/src/windows/gfx/d3d12.c
+++ b/src/windows/gfx/d3d12.c
@@ -560,9 +560,7 @@ bool mty_d3d12_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	D3D12_VIEWPORT vp = {0};
-	mty_viewport(desc->rotation, desc->cropWidth, desc->cropHeight,
-		desc->viewWidth, desc->viewHeight, desc->aspectRatio, desc->scale,
-		&vp.TopLeftX, &vp.TopLeftY, &vp.Width, &vp.Height);
+	mty_viewport(desc, &vp.TopLeftX, &vp.TopLeftY, &vp.Width, &vp.Height, false);
 
 	ID3D12GraphicsCommandList_RSSetViewports(cl, 1, &vp);
 

--- a/src/windows/gfx/d3d12.c
+++ b/src/windows/gfx/d3d12.c
@@ -574,8 +574,10 @@ bool mty_d3d12_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 	if (_dest) {
 		ID3D12GraphicsCommandList_OMSetRenderTargets(cl, 1, _dest, FALSE, NULL);
 
-		const float color[4] = {0.0f, 0.0f, 0.0f, 1.0f};
-		ID3D12GraphicsCommandList_ClearRenderTargetView(cl, *_dest, color, 0, NULL);
+		if (desc->clear) {
+			const float color[4] = {0.0f, 0.0f, 0.0f, 1.0f};
+			ID3D12GraphicsCommandList_ClearRenderTargetView(cl, *_dest, color, 0, NULL);
+		}
 	}
 
 	// Set up pipeline

--- a/src/windows/gfx/d3d9.c
+++ b/src/windows/gfx/d3d9.c
@@ -215,12 +215,20 @@ static HRESULT d3d9_reload_textures(struct d3d9 *ctx, IDirect3DDevice9 *device,
 {
 	switch (desc->format) {
 		case MTY_COLOR_FORMAT_BGRA:
+		case MTY_COLOR_FORMAT_RGBA:
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
 		case MTY_COLOR_FORMAT_BGRA5551: {
-			D3DFORMAT format = desc->format == MTY_COLOR_FORMAT_BGR565 ? D3DFMT_R5G6B5 :
-				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? D3DFMT_X1R5G5B5 : D3DFMT_A8R8G8B8;
-			uint8_t bpp = (desc->format == MTY_COLOR_FORMAT_BGRA || desc->format == MTY_COLOR_FORMAT_AYUV) ? 4 : 2;
+			D3DFORMAT format =
+				desc->format == MTY_COLOR_FORMAT_BGR565   ? D3DFMT_R5G6B5   :
+				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? D3DFMT_X1R5G5B5 :
+				desc->format == MTY_COLOR_FORMAT_RGBA     ? D3DFMT_A8B8G8R8 :
+				D3DFMT_A8R8G8B8;
+			uint8_t bpp =
+				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
+				sizeof(uint16_t);
 
 			// BGRA
 			HRESULT e = d3d9_refresh_resource(&ctx->staging[0], device, format, desc->cropWidth, desc->cropHeight);

--- a/src/windows/gfx/d3d9.c
+++ b/src/windows/gfx/d3d9.c
@@ -315,9 +315,7 @@ bool mty_d3d9_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	float vpx, vpy, vpw, vph;
-	mty_viewport(desc->rotation, desc->cropWidth, desc->cropHeight,
-		desc->viewWidth, desc->viewHeight, desc->aspectRatio, desc->scale,
-		&vpx, &vpy, &vpw, &vph);
+	mty_viewport(desc, &vpx, &vpy, &vpw, &vph, false);
 
 	D3DVIEWPORT9 vp = {0};
 	vp.X = lrint(vpx);

--- a/src/windows/gfx/d3d9.c
+++ b/src/windows/gfx/d3d9.c
@@ -364,6 +364,14 @@ bool mty_d3d9_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 		goto except;
 	}
 
+	if (desc->blend) {
+		IDirect3DDevice9_SetRenderState(_device, D3DRS_ALPHABLENDENABLE, true);
+		IDirect3DDevice9_SetRenderState(_device, D3DRS_ALPHATESTENABLE, false);
+		IDirect3DDevice9_SetRenderState(_device, D3DRS_BLENDOP, D3DBLENDOP_ADD);
+		IDirect3DDevice9_SetRenderState(_device, D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
+		IDirect3DDevice9_SetRenderState(_device, D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
+	}
+
 	// D3D9 half texel fix
 	float texel_offset[4] = {0};
 	texel_offset[0] = -1.0f / (float) vp.Width;

--- a/src/windows/gfx/d3d9.c
+++ b/src/windows/gfx/d3d9.c
@@ -306,10 +306,12 @@ bool mty_d3d9_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 			goto except;
 		}
 
-		e = IDirect3DDevice9_Clear(_device, 0, NULL, D3DCLEAR_TARGET, D3DCOLOR_XRGB(0, 0, 0), 1.0f, 0);
-		if (e != D3D_OK) {
-			MTY_Log("'IDirect3DDevice9_Clear' failed with HRESULT 0x%X", e);
-			goto except;
+		if (desc->clear) {
+			e = IDirect3DDevice9_Clear(_device, 0, NULL, D3DCLEAR_TARGET, D3DCOLOR_XRGB(0, 0, 0), 1.0f, 0);
+			if (e != D3D_OK) {
+				MTY_Log("'IDirect3DDevice9_Clear' failed with HRESULT 0x%X", e);
+				goto except;
+			}
 		}
 	}
 

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -317,7 +317,7 @@ bool MTY_ZoomHasMoved(MTY_Zoom *ctx)
 	bool has_moved = status != ctx->status;
 	ctx->status = status;
 
-	return has_moved;
+	return has_moved || ctx->scaling;
 }
 
 bool MTY_ZoomShouldShowCursor(MTY_Zoom *ctx)

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -188,17 +188,17 @@ void MTY_ZoomMove(MTY_Zoom *ctx, int32_t x, int32_t y, bool start)
 	ctx->cursor.x += delta_x / ctx->scale_screen;
 	ctx->cursor.y += delta_y / ctx->scale_screen;
 
-	if (ctx->cursor.x < 0)
-		ctx->cursor.x = 0;
+	if (ctx->cursor.x < ctx->image_min.x)
+		ctx->cursor.x = ctx->image_min.x;
 
-	if (ctx->cursor.y < 0)
-		ctx->cursor.y = 0;
+	if (ctx->cursor.y < ctx->image_min.y)
+		ctx->cursor.y = ctx->image_min.y;
 
-	if (ctx->cursor.x > ctx->window_w)
-		ctx->cursor.x = (float) ctx->window_w;
+	if (ctx->cursor.x > ctx->window_w - ctx->image_min.x)
+		ctx->cursor.x = ctx->window_w - ctx->image_min.x;
 
-	if (ctx->cursor.y > ctx->window_h)
-		ctx->cursor.y = (float) ctx->window_h;
+	if (ctx->cursor.y > ctx->window_h - ctx->image_min.y)
+		ctx->cursor.y = ctx->window_h - ctx->image_min.y;
 
 	float left   = mty_zoom_tranform_x(ctx, ctx->margin);
 	float right  = mty_zoom_tranform_x(ctx, ctx->window_w - ctx->margin);

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -12,6 +12,7 @@ struct MTY_Zoom {
 
 	MTY_Point origin;
 	MTY_Point cursor;
+	MTY_Point cursor_prev;
 	float margin;
 
 	uint32_t image_w;
@@ -301,6 +302,16 @@ void MTY_ZoomSetMode(MTY_Zoom *ctx, MTY_InputMode mode)
 
 	if (ctx->mode == MTY_INPUT_MODE_UNSPECIFIED)
 		ctx->mode = MTY_INPUT_MODE_TOUCHSCREEN;
+}
+
+bool MTY_ZoomHasMoved(MTY_Zoom *ctx)
+{
+	bool has_moved = ctx->cursor.x != ctx->cursor_prev.x || ctx->cursor.y != ctx->cursor_prev.y;
+
+	ctx->cursor_prev.x = ctx->cursor.x;
+	ctx->cursor_prev.y = ctx->cursor.y;
+
+	return has_moved;
 }
 
 bool MTY_ZoomShouldShowCursor(MTY_Zoom *ctx)

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -1,0 +1,193 @@
+#include "matoya.h"
+
+struct MTY_Zoom {
+	bool scaling;
+
+	MTY_Point image;
+	MTY_Point image_min;
+	MTY_Point image_max;
+	MTY_Point focus;
+	MTY_Point focus_delta;
+
+	uint32_t image_w;
+	uint32_t image_h;
+	uint32_t window_w;
+	uint32_t window_h;
+
+	float scale_delta;
+	float scale_image;
+	float scale_image_min;
+	float scale_screen;
+};
+
+MTY_Zoom *MTY_ZoomCreate(uint32_t windowWidth, uint32_t windowHeight) 
+{
+	MTY_Zoom *ctx = MTY_Alloc(1, sizeof(MTY_Zoom));
+
+	ctx->scale_delta = 1;
+	ctx->scale_screen = 1;
+	ctx->window_w = windowWidth;
+	ctx->window_h = windowHeight;
+
+	return ctx;
+}
+
+static void mty_zoom_reset(MTY_Zoom *ctx, uint32_t imageWidth, uint32_t imageHeight, bool force)
+{
+	if (!ctx)
+		return;
+
+	bool same_image = ctx->image_w == imageWidth && ctx->image_h == imageHeight;
+	if (!force && same_image)
+		return;
+
+	ctx->image_w  = imageWidth;
+	ctx->image_h  = imageHeight;
+
+	ctx->scale_image = ctx->window_w < ctx->window_h
+		? (float)ctx->window_w / ctx->image_w
+		: (float)ctx->window_h / ctx->image_h;
+	ctx->scale_delta = 1;
+	ctx->scale_screen = 1;
+
+	ctx->image.x = 0;
+	ctx->image.y = 0;
+	if (ctx->window_w > ctx->window_h) 
+		ctx->image.x = (ctx->window_w - ctx->image_w * ctx->scale_image) / 2.0f;
+	if (ctx->window_w < ctx->window_h)
+		ctx->image.y = (ctx->window_h - ctx->image_h * ctx->scale_image) / 2.0f;
+
+	ctx->scale_image_min   = ctx->scale_image;
+	ctx->image_min.x = ctx->image.x;
+	ctx->image_min.y = ctx->image.y;
+	ctx->image_max.x = ctx->window_w - ctx->image.x;
+	ctx->image_max.y = ctx->window_h - ctx->image.y;
+
+	ctx->focus.x = 0;
+	ctx->focus.y = 0;
+	ctx->focus_delta.x = 0;
+	ctx->focus_delta.y = 0;
+}
+
+void MTY_ZoomProcess(MTY_Zoom *ctx, uint32_t imageWidth, uint32_t imageHeight)
+{
+	if (!ctx)
+		return;
+
+	mty_zoom_reset(ctx, imageWidth, imageHeight, false);
+
+	if (ctx->scale_delta == 1)
+		return;
+
+	ctx->scale_image  *= ctx->scale_delta;
+	ctx->scale_screen *= ctx->scale_delta;
+	if (ctx->scale_image < ctx->scale_image_min) {
+		ctx->scale_image = ctx->scale_image_min;
+		ctx->scale_delta = 1;
+		ctx->scale_screen = 1;
+	}
+
+	ctx->image.x = ctx->focus.x - ctx->scale_delta * (ctx->focus.x - ctx->image.x);
+	ctx->image.y = ctx->focus.y - ctx->scale_delta * (ctx->focus.y - ctx->image.y);
+
+	if (ctx->focus_delta.x || ctx->focus_delta.y) {
+		ctx->image.x += ctx->focus_delta.x;
+		ctx->image.y += ctx->focus_delta.y;
+
+		ctx->focus_delta.x = 0;
+		ctx->focus_delta.y = 0;
+	}
+
+	float image_scaled_w = ctx->image_w * ctx->scale_image;
+	float image_scaled_h = ctx->image_h * ctx->scale_image;
+
+	if (ctx->image.x > ctx->image_min.x)
+		ctx->image.x = ctx->image_min.x;
+
+	if (ctx->image.y > ctx->image_min.y)
+		ctx->image.y = ctx->image_min.y;
+
+	if (ctx->image.x < ctx->image_max.x - image_scaled_w)
+		ctx->image.x = ctx->image_max.x - image_scaled_w;
+
+	if (ctx->image.y < ctx->image_max.y - image_scaled_h)
+		ctx->image.y = ctx->image_max.y - image_scaled_h;
+
+	ctx->scale_delta = 1;
+}
+
+void MTY_ZoomFeed(MTY_Zoom *ctx, float scaleFactor, float focusX, float focusY)
+{
+	if (!ctx)
+		return;
+
+	if (ctx->scaling) {
+		ctx->scale_delta *= scaleFactor;
+		ctx->focus_delta.x += focusX - ctx->focus.x;
+		ctx->focus_delta.y += focusY - ctx->focus.y;
+	}
+
+	ctx->focus.x = focusX;
+	ctx->focus.y = focusY;
+}
+
+void MTY_ZoomResizeWindow(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight)
+{
+	ctx->window_w = windowWidth;
+	ctx->window_h = windowHeight;
+
+	mty_zoom_reset(ctx, ctx->image_w, ctx->image_h, true);
+}
+
+int32_t MTY_ZoomTranformX(MTY_Zoom *ctx, int32_t value)
+{
+	float offset_x = - ctx->image.x / ctx->scale_screen + ctx->image_min.x;
+	float zoom_w   = ctx->window_w / ctx->scale_screen;
+	float ratio_x  = (float) value / ctx->window_w;
+
+	return (int32_t) (offset_x + zoom_w * ratio_x);
+}
+
+int32_t MTY_ZoomTranformY(MTY_Zoom *ctx, int32_t value)
+{
+	float offset_y = - ctx->image.y / ctx->scale_screen + ctx->image_min.y;
+	float zoom_h   = ctx->window_h / ctx->scale_screen;
+	float ratio_y  = (float) value / ctx->window_h;
+
+	return (int32_t) (offset_y + zoom_h * ratio_y);
+}
+
+float MTY_ZoomGetScale(MTY_Zoom *ctx)
+{
+	return ctx->scale_image;
+}
+
+int32_t MTY_ZoomGetImageX(MTY_Zoom *ctx)
+{
+	return (int32_t) ctx->image.x;
+}
+
+int32_t MTY_ZoomGetImageY(MTY_Zoom *ctx)
+{
+	return (int32_t) ctx->image.y;
+}
+
+
+void MTY_ZoomSetScaling(MTY_Zoom *ctx, bool scaling)
+{
+	ctx->scaling = scaling;
+}
+
+bool MTY_ZoomIsScaling(MTY_Zoom *ctx)
+{
+	return ctx->scaling;
+}
+
+void MTY_ZoomDestroy(MTY_Zoom **ctx)
+{
+	if (!(*ctx))
+		return;
+
+	MTY_Free(*ctx);
+	*ctx = NULL;
+}

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -4,6 +4,7 @@ struct MTY_Zoom {
 	MTY_InputMode mode;
 	bool scaling;
 	bool relative;
+	bool postpone;
 
 	MTY_Point image;
 	MTY_Point image_min;
@@ -176,7 +177,12 @@ void MTY_ZoomMove(MTY_Zoom *ctx, int32_t x, int32_t y, bool start)
 		return;
 	}
 
-	if (start) {
+	if (start || ctx->postpone) {
+		ctx->postpone = ctx->relative;
+
+		if (ctx->postpone)
+			return;
+
 		ctx->origin.x = (float) x;
 		ctx->origin.y = (float) y;
 		return;

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -102,15 +102,15 @@ void MTY_ZoomUpdate(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight, 
 	ctx->image_h = imageHeight;
 
 	ctx->scale_screen = 1;
-	ctx->scale_image = ctx->window_w < ctx->window_h
-		? (float) ctx->window_w / ctx->image_w
-		: (float) ctx->window_h / ctx->image_h;
+	float scale_w = (float) ctx->window_w / ctx->image_w;
+	float scale_h = (float) ctx->window_h / ctx->image_h;
+	ctx->scale_image = scale_w < scale_h ? scale_w : scale_h;
 
 	ctx->image.x = 0;
 	ctx->image.y = 0;
-	if (ctx->window_w > ctx->window_h) 
+	if (scale_w > scale_h) 
 		ctx->image.x = (ctx->window_w - ctx->image_w * ctx->scale_image) / 2.0f;
-	if (ctx->window_w < ctx->window_h)
+	if (scale_w < scale_h) 
 		ctx->image.y = (ctx->window_h - ctx->image_h * ctx->scale_image) / 2.0f;
 
 	ctx->image_min.x = ctx->image.x;

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -7,17 +7,19 @@ struct MTY_Zoom {
 	MTY_Point image_min;
 	MTY_Point image_max;
 	MTY_Point focus;
-	MTY_Point focus_delta;
 
 	uint32_t image_w;
 	uint32_t image_h;
 	uint32_t window_w;
 	uint32_t window_h;
 
-	float scale_delta;
+	float scale_screen;
+	float scale_screen_min;
+	float scale_screen_max;
 	float scale_image;
 	float scale_image_min;
-	float scale_screen;
+	float scale_image_max;
+	float scale_delta;
 };
 
 MTY_Zoom *MTY_ZoomCreate(uint32_t windowWidth, uint32_t windowHeight) 
@@ -26,6 +28,9 @@ MTY_Zoom *MTY_ZoomCreate(uint32_t windowWidth, uint32_t windowHeight)
 
 	ctx->scale_delta = 1;
 	ctx->scale_screen = 1;
+	ctx->scale_screen_min = 1;
+	ctx->scale_screen_max = 4;
+	ctx->scale_delta = 1;
 	ctx->window_w = windowWidth;
 	ctx->window_h = windowHeight;
 
@@ -44,11 +49,11 @@ static void mty_zoom_reset(MTY_Zoom *ctx, uint32_t imageWidth, uint32_t imageHei
 	ctx->image_w  = imageWidth;
 	ctx->image_h  = imageHeight;
 
+	ctx->scale_screen = 1;
 	ctx->scale_image = ctx->window_w < ctx->window_h
 		? (float)ctx->window_w / ctx->image_w
 		: (float)ctx->window_h / ctx->image_h;
 	ctx->scale_delta = 1;
-	ctx->scale_screen = 1;
 
 	ctx->image.x = 0;
 	ctx->image.y = 0;
@@ -57,16 +62,16 @@ static void mty_zoom_reset(MTY_Zoom *ctx, uint32_t imageWidth, uint32_t imageHei
 	if (ctx->window_w < ctx->window_h)
 		ctx->image.y = (ctx->window_h - ctx->image_h * ctx->scale_image) / 2.0f;
 
-	ctx->scale_image_min   = ctx->scale_image;
 	ctx->image_min.x = ctx->image.x;
 	ctx->image_min.y = ctx->image.y;
 	ctx->image_max.x = ctx->window_w - ctx->image.x;
 	ctx->image_max.y = ctx->window_h - ctx->image.y;
 
+	ctx->scale_image_min = ctx->scale_image * ctx->scale_screen_min;
+	ctx->scale_image_max = ctx->scale_image * ctx->scale_screen_max;
+
 	ctx->focus.x = 0;
 	ctx->focus.y = 0;
-	ctx->focus_delta.x = 0;
-	ctx->focus_delta.y = 0;
 }
 
 void MTY_ZoomProcess(MTY_Zoom *ctx, uint32_t imageWidth, uint32_t imageHeight)
@@ -76,27 +81,23 @@ void MTY_ZoomProcess(MTY_Zoom *ctx, uint32_t imageWidth, uint32_t imageHeight)
 
 	mty_zoom_reset(ctx, imageWidth, imageHeight, false);
 
-	if (ctx->scale_delta == 1)
-		return;
-
-	ctx->scale_image  *= ctx->scale_delta;
 	ctx->scale_screen *= ctx->scale_delta;
-	if (ctx->scale_image < ctx->scale_image_min) {
-		ctx->scale_image = ctx->scale_image_min;
-		ctx->scale_delta = 1;
-		ctx->scale_screen = 1;
+	ctx->scale_image  *= ctx->scale_delta;
+	
+	if (ctx->scale_screen < ctx->scale_screen_min) {
+		ctx->scale_screen = ctx->scale_screen_min;
+		ctx->scale_image  = ctx->scale_image_min;
+		ctx->scale_delta  = 1;
+	}
+
+	if (ctx->scale_screen > ctx->scale_screen_max) {
+		ctx->scale_screen = ctx->scale_screen_max;
+		ctx->scale_image  = ctx->scale_image_max;
+		ctx->scale_delta  = 1;
 	}
 
 	ctx->image.x = ctx->focus.x - ctx->scale_delta * (ctx->focus.x - ctx->image.x);
 	ctx->image.y = ctx->focus.y - ctx->scale_delta * (ctx->focus.y - ctx->image.y);
-
-	if (ctx->focus_delta.x || ctx->focus_delta.y) {
-		ctx->image.x += ctx->focus_delta.x;
-		ctx->image.y += ctx->focus_delta.y;
-
-		ctx->focus_delta.x = 0;
-		ctx->focus_delta.y = 0;
-	}
 
 	float image_scaled_w = ctx->image_w * ctx->scale_image;
 	float image_scaled_h = ctx->image_h * ctx->scale_image;
@@ -123,8 +124,8 @@ void MTY_ZoomFeed(MTY_Zoom *ctx, float scaleFactor, float focusX, float focusY)
 
 	if (ctx->scaling) {
 		ctx->scale_delta *= scaleFactor;
-		ctx->focus_delta.x += focusX - ctx->focus.x;
-		ctx->focus_delta.y += focusY - ctx->focus.y;
+		ctx->image.x += focusX - ctx->focus.x;
+		ctx->image.y += focusY - ctx->focus.y;
 	}
 
 	ctx->focus.x = focusX;
@@ -137,6 +138,12 @@ void MTY_ZoomResizeWindow(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHe
 	ctx->window_h = windowHeight;
 
 	mty_zoom_reset(ctx, ctx->image_w, ctx->image_h, true);
+}
+
+void MTY_ZoomSetLimits(MTY_Zoom *ctx, float min, float max)
+{
+	ctx->scale_screen_min = min;
+	ctx->scale_screen_max = max;
 }
 
 int32_t MTY_ZoomTranformX(MTY_Zoom *ctx, int32_t value)
@@ -171,7 +178,6 @@ int32_t MTY_ZoomGetImageY(MTY_Zoom *ctx)
 {
 	return (int32_t) ctx->image.y;
 }
-
 
 void MTY_ZoomSetScaling(MTY_Zoom *ctx, bool scaling)
 {

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -2,11 +2,15 @@
 
 struct MTY_Zoom {
 	bool scaling;
+	bool relative;
 
 	MTY_Point image;
 	MTY_Point image_min;
 	MTY_Point image_max;
 	MTY_Point focus;
+
+	MTY_Point origin;
+	MTY_Point cursor;
 
 	uint32_t image_w;
 	uint32_t image_h;
@@ -70,8 +74,29 @@ static void mty_zoom_reset(MTY_Zoom *ctx, uint32_t imageWidth, uint32_t imageHei
 	ctx->scale_image_min = ctx->scale_image * ctx->scale_screen_min;
 	ctx->scale_image_max = ctx->scale_image * ctx->scale_screen_max;
 
+	ctx->cursor.x = ctx->window_w / 2.0f;
+	ctx->cursor.y = ctx->window_h / 2.0f;
+
 	ctx->focus.x = 0;
 	ctx->focus.y = 0;
+}
+
+static float mty_zoom_tranform_x(MTY_Zoom *ctx, float value)
+{
+	float offset_x = - ctx->image.x / ctx->scale_screen + ctx->image_min.x;
+	float zoom_w   = ctx->window_w / ctx->scale_screen;
+	float ratio_x  = (float) value / ctx->window_w;
+
+	return offset_x + zoom_w * ratio_x;
+}
+
+static float mty_zoom_tranform_y(MTY_Zoom *ctx, float value)
+{
+	float offset_y = - ctx->image.y / ctx->scale_screen + ctx->image_min.y;
+	float zoom_h   = ctx->window_h / ctx->scale_screen;
+	float ratio_y  = (float) value / ctx->window_h;
+
+	return offset_y + zoom_h * ratio_y;
 }
 
 void MTY_ZoomProcess(MTY_Zoom *ctx, uint32_t imageWidth, uint32_t imageHeight)
@@ -114,6 +139,11 @@ void MTY_ZoomProcess(MTY_Zoom *ctx, uint32_t imageWidth, uint32_t imageHeight)
 	if (ctx->image.y < ctx->image_max.y - image_scaled_h)
 		ctx->image.y = ctx->image_max.y - image_scaled_h;
 
+	if (ctx->scaling) {
+		ctx->cursor.x = mty_zoom_tranform_x(ctx, ctx->window_w / 2.0f);
+		ctx->cursor.y = mty_zoom_tranform_y(ctx, ctx->window_h / 2.0f);
+	}
+
 	ctx->scale_delta = 1;
 }
 
@@ -132,6 +162,62 @@ void MTY_ZoomFeed(MTY_Zoom *ctx, float scaleFactor, float focusX, float focusY)
 	ctx->focus.y = focusY;
 }
 
+void MTY_ZoomMove(MTY_Zoom *ctx, int32_t x, int32_t y, bool start)
+{
+	if (ctx->scaling)
+		return;
+
+	if (!ctx->relative) {
+		ctx->cursor.x = mty_zoom_tranform_x(ctx, x);
+		ctx->cursor.y = mty_zoom_tranform_y(ctx, y);
+		return;
+	}
+
+	if (start) {
+		ctx->origin.x = (float) x;
+		ctx->origin.y = (float) y;
+		return;
+	}
+
+	float delta_x = x - ctx->origin.x;
+	float delta_y = y - ctx->origin.y;
+
+	ctx->cursor.x += delta_x / ctx->scale_screen;
+	ctx->cursor.y += delta_y / ctx->scale_screen;
+
+	if (ctx->cursor.x < 0)
+		ctx->cursor.x = 0;
+
+	if (ctx->cursor.y < 0)
+		ctx->cursor.y = 0;
+
+	if (ctx->cursor.x > ctx->window_w)
+		ctx->cursor.x = (float) ctx->window_w;
+
+	if (ctx->cursor.y > ctx->window_h)
+		ctx->cursor.y = (float) ctx->window_h;
+
+	float left   = mty_zoom_tranform_x(ctx, ctx->window_w * 0.2f);
+	float right  = mty_zoom_tranform_x(ctx, ctx->window_w * 0.8f);
+	float top    = mty_zoom_tranform_y(ctx, ctx->window_h * 0.2f);
+	float bottom = mty_zoom_tranform_y(ctx, ctx->window_h * 0.8f);
+
+	if (delta_x < 0 && ctx->cursor.x < left)
+		ctx->image.x -= delta_x;
+
+	if (delta_x > 0 && ctx->cursor.x > right)
+		ctx->image.x -= delta_x;
+
+	if (delta_y < 0 && ctx->cursor.y < top)
+		ctx->image.y -= delta_y;
+
+	if (delta_y > 0 && ctx->cursor.y > bottom)
+		ctx->image.y -= delta_y;
+
+	ctx->origin.x = (float) x;
+	ctx->origin.y = (float) y;
+}
+
 void MTY_ZoomResizeWindow(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight)
 {
 	ctx->window_w = windowWidth;
@@ -146,22 +232,25 @@ void MTY_ZoomSetLimits(MTY_Zoom *ctx, float min, float max)
 	ctx->scale_screen_max = max;
 }
 
+void MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative)
+{
+	ctx->relative = relative;
+}
+
 int32_t MTY_ZoomTranformX(MTY_Zoom *ctx, int32_t value)
 {
-	float offset_x = - ctx->image.x / ctx->scale_screen + ctx->image_min.x;
-	float zoom_w   = ctx->window_w / ctx->scale_screen;
-	float ratio_x  = (float) value / ctx->window_w;
+	if (ctx->relative)
+		return (int32_t) ctx->cursor.x;
 
-	return (int32_t) (offset_x + zoom_w * ratio_x);
+	return (int32_t) mty_zoom_tranform_x(ctx, (float) value);
 }
 
 int32_t MTY_ZoomTranformY(MTY_Zoom *ctx, int32_t value)
 {
-	float offset_y = - ctx->image.y / ctx->scale_screen + ctx->image_min.y;
-	float zoom_h   = ctx->window_h / ctx->scale_screen;
-	float ratio_y  = (float) value / ctx->window_h;
+	if (ctx->relative)
+		return (int32_t) ctx->cursor.y;
 
-	return (int32_t) (offset_y + zoom_h * ratio_y);
+	return (int32_t) mty_zoom_tranform_y(ctx, (float) value);
 }
 
 float MTY_ZoomGetScale(MTY_Zoom *ctx)

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -305,12 +305,9 @@ void MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative)
 	ctx->relative = relative;
 }
 
-void MTY_ZoomSetMode(MTY_Zoom *ctx, MTY_InputMode mode)
+void MTY_ZoomEnableTrackpad(MTY_Zoom *ctx, bool enable)
 {
-	ctx->mode = mode;
-
-	if (ctx->mode == MTY_INPUT_MODE_UNSPECIFIED)
-		ctx->mode = MTY_INPUT_MODE_TOUCHSCREEN;
+	ctx->mode = enable ? MTY_INPUT_MODE_TRACKPAD : MTY_INPUT_MODE_TOUCHSCREEN;
 }
 
 bool MTY_ZoomHasMoved(MTY_Zoom *ctx)

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -1,7 +1,7 @@
 #include "matoya.h"
 
-// XXX Required because clicks does not always fire on the very edges
-#define EDGE_PADDING 5.0f
+// XXX Required because clicks does not always fire on the edges
+#define EDGE_PADDING 1.0f
 
 struct MTY_Zoom {
 	MTY_InputMode mode;
@@ -303,6 +303,11 @@ bool MTY_ZoomIsRelative(MTY_Zoom *ctx)
 void MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative)
 {
 	ctx->relative = relative;
+}
+
+bool MTY_ZoomIsTrackpadEnabled(MTY_Zoom *ctx)
+{
+	return ctx->mode == MTY_INPUT_MODE_TRACKPAD;
 }
 
 void MTY_ZoomEnableTrackpad(MTY_Zoom *ctx, bool enable)

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -1,5 +1,8 @@
 #include "matoya.h"
 
+// XXX Required because clicks does not always fire on the very edges
+#define EDGE_PADDING 5.0f
+
 struct MTY_Zoom {
 	MTY_InputMode mode;
 	bool scaling;
@@ -194,17 +197,17 @@ void MTY_ZoomMove(MTY_Zoom *ctx, int32_t x, int32_t y, bool start)
 	ctx->cursor.x += delta_x / ctx->scale_screen;
 	ctx->cursor.y += delta_y / ctx->scale_screen;
 
-	if (ctx->cursor.x < ctx->image_min.x)
-		ctx->cursor.x = ctx->image_min.x;
+	if (ctx->cursor.x < ctx->image_min.x + EDGE_PADDING)
+		ctx->cursor.x = ctx->image_min.x + EDGE_PADDING;
 
-	if (ctx->cursor.y < ctx->image_min.y)
-		ctx->cursor.y = ctx->image_min.y;
+	if (ctx->cursor.y < ctx->image_min.y + EDGE_PADDING)
+		ctx->cursor.y = ctx->image_min.y + EDGE_PADDING;
 
-	if (ctx->cursor.x > ctx->window_w - ctx->image_min.x)
-		ctx->cursor.x = ctx->window_w - ctx->image_min.x;
+	if (ctx->cursor.x > ctx->window_w - ctx->image_min.x - EDGE_PADDING)
+		ctx->cursor.x = ctx->window_w - ctx->image_min.x - EDGE_PADDING;
 
-	if (ctx->cursor.y > ctx->window_h - ctx->image_min.y)
-		ctx->cursor.y = ctx->window_h - ctx->image_min.y;
+	if (ctx->cursor.y > ctx->window_h - ctx->image_min.y - EDGE_PADDING)
+		ctx->cursor.y = ctx->window_h - ctx->image_min.y - EDGE_PADDING;
 
 	float left   = mty_zoom_tranform_x(ctx, ctx->margin);
 	float right  = mty_zoom_tranform_x(ctx, ctx->window_w - ctx->margin);

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -103,8 +103,8 @@ void MTY_ZoomUpdate(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight, 
 
 	ctx->scale_screen = 1;
 	ctx->scale_image = ctx->window_w < ctx->window_h
-		? (float)ctx->window_w / ctx->image_w
-		: (float)ctx->window_h / ctx->image_h;
+		? (float) ctx->window_w / ctx->image_w
+		: (float) ctx->window_h / ctx->image_h;
 
 	ctx->image.x = 0;
 	ctx->image.y = 0;

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -12,8 +12,8 @@ struct MTY_Zoom {
 
 	MTY_Point origin;
 	MTY_Point cursor;
-	MTY_Point cursor_prev;
 	float margin;
+	float status;
 
 	uint32_t image_w;
 	uint32_t image_h;
@@ -306,10 +306,10 @@ void MTY_ZoomSetMode(MTY_Zoom *ctx, MTY_InputMode mode)
 
 bool MTY_ZoomHasMoved(MTY_Zoom *ctx)
 {
-	bool has_moved = ctx->cursor.x != ctx->cursor_prev.x || ctx->cursor.y != ctx->cursor_prev.y;
+	float status = ctx->cursor.x + ctx->cursor.y + ctx->image.x + ctx->image.y;
 
-	ctx->cursor_prev.x = ctx->cursor.x;
-	ctx->cursor_prev.y = ctx->cursor.y;
+	bool has_moved = status != ctx->status;
+	ctx->status = status;
 
 	return has_moved;
 }


### PR DESCRIPTION
This PR actually adds a bunch of new features to add global scaling support (for now only supported on Android).
* Fix `MTY_COLOR_FORMAT_BGRA` display on Android: in OpenGL ES, the `internal` and `format` parameters must match.  `MTY_COLOR_FORMAT_RGBA` is also added as it improves the color formats panel.
* Support for `MTY_WindowDrawQuad` positioning: `MTY_Position` has been created to define how a frame is displayed on the screen. It defaults to `MTY_POSITION_AUTO`, which is the original behavior. When `MTY_POSITION_FIXED` is set, `imageX` and `imageY` can be set to position the frame. In this mode, automatic scaling is disabled and must be set in the `scale` property by the client.
* New event `MTY_EVENT_SCALE`: This new event is sent when a scaling event is detected. It contains the focus position and the scaling factor relative to the previous scaling event. This event is currently only sent from the Android platform.
* Added `MTY_MotionFlag`: This flag exposes whether a motion event comes from a touch event, and if a motion gesture has just started. Those flags are currently only set when using the Android platform.
* Added the possibility to draw multiple quads before presenting: A `clear` property has been added to `MTY_DrawDesc` to trigger screen clearing. The window will only be cleared if this property is set, and therefore allows for multiple drawings. A typical usage is to clear on the first `MTY_WindowDrawQuad` call in the application loop.
* Added blending support to `MTY_WindowDrawQuad`: By setting the `blend` property on `MTY_DrawDesc`, blending will be enabled for the corresponding `MTY_WindowDrawQuad`, which allows to make use of the frame's alpha channel if available. This is currently only supported with `MTY_GFX_GL`, `MTY_GFX_D3D9` and `MTY_GFX_D3D11`.
* Added `MTY_Zoom` module: This module provides out-of-the-box coordinates conversion and cursor positioning, based of on the `MTY_EVENT_MOTION` and `MTY_EVENT_SCALE` events' data. It supports multiple modes:
  * `MTY_INPUT_MODE_TOUCHSCREEN`: In this mode, the cursor position is directly transformed from the absolute screen coordinates to the zoomed viewport, and the image is never moved.
  * `MTY_INPUT_MODE_TRACKPAD`: In this mode, the cursor position is computed relatively from motion events, and the image is moved in case the cursor hits the borders of the zoomed viewport.
  * Relative: This special mode is made for when the input data are relative and the cursor position must not be converted.
* Added `MTY_Cursor` module: This helper module allows to create, setup and draw a cursor. This is basically a wrapper around `MTY_WindowDrawQuad`.