### PR TITLE
[android-zoom] Add MTY_Zoom and MTY_Cursor modules

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -39,6 +39,7 @@ LOCAL_CFLAGS = $(DEFS) $(FLAGS)
 LOCAL_SRC_FILES := \
 	src/app.c \
 	src/crypto.c \
+	src/cursor.c \
 	src/file.c \
 	src/hash.c \
 	src/image.c \

--- a/Android.mk
+++ b/Android.mk
@@ -53,6 +53,7 @@ LOCAL_SRC_FILES := \
 	src/tlocal.c \
 	src/tls.c \
 	src/version.c \
+	src/zoom.c \
 	src/gfx/gl.c \
 	src/gfx/gl-ui.c \
 	src/hid/utils.c \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,6 +16,7 @@ NAME = libmatoya
 OBJS = \
 	src/app.o \
 	src/crypto.o \
+	src/cursor.o \
 	src/file.o \
 	src/hash.o \
 	src/image.o \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -30,6 +30,7 @@ OBJS = \
 	src/tlocal.o \
 	src/tls.o \
 	src/version.o \
+	src/zoom.o \
 	src/gfx/gl.o \
 	src/gfx/gl-ui.o \
 	src/hid/utils.o \

--- a/makefile
+++ b/makefile
@@ -39,6 +39,7 @@ OBJS = \
 	src\tlocal.obj \
 	src\tls.obj \
 	src\version.obj \
+	src\zoom.obj \
 	src\gfx\gl.obj \
 	src\gfx\gl-ui.obj \
 	src\hid\hid.obj \

--- a/makefile
+++ b/makefile
@@ -25,6 +25,7 @@ NAME = matoya
 OBJS = \
 	src\app.obj \
 	src\crypto.obj \
+	src\cursor.obj \
 	src\file.obj \
 	src\hash.obj \
 	src\image.obj \

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -1,0 +1,95 @@
+#include "matoya.h"
+
+struct MTY_Cursor {
+    MTY_App *app;
+	bool enabled;
+	void *image;
+	uint32_t width;
+	uint32_t height;
+	uint16_t hotX;
+	uint16_t hotY;
+	int32_t x;
+	int32_t y;
+	float scale;
+};
+
+MTY_Cursor *MTY_CursorCreate(MTY_App *app)
+{
+    MTY_Cursor *ctx = MTY_Alloc(1, sizeof(MTY_Cursor));
+
+    ctx->app = app;
+	ctx->enabled = true;
+
+    return ctx;
+}
+
+void MTY_CursorEnable(MTY_Cursor *ctx, bool enable)
+{
+	ctx->enabled = enable;
+}
+
+void MTY_CursorSetHotspot(MTY_Cursor *ctx, uint16_t hotX, uint16_t hotY)
+{
+    ctx->hotX = hotX;
+    ctx->hotY = hotY;
+}
+
+void MTY_CursorSetImage(MTY_Cursor *ctx, const void *data, size_t size)
+{
+	if (ctx->image)
+		MTY_Free(ctx->image);
+
+    ctx->image = MTY_DecompressImage(data, size, &ctx->width, &ctx->height);
+}
+
+void MTY_CursorMove(MTY_Cursor *ctx, int32_t x, int32_t y, float scale)
+{
+    ctx->scale = scale;
+    ctx->x = x;
+    ctx->y = y;
+}
+
+void MTY_CursorMoveFromZoom(MTY_Cursor *ctx, MTY_Zoom *zoom)
+{
+	float scale = MTY_ZoomGetScale(zoom);
+	int32_t cursor_x = MTY_ZoomGetCursorX(zoom);
+	int32_t cursor_y = MTY_ZoomGetCursorY(zoom);
+	
+	MTY_CursorMove(ctx, cursor_x, cursor_y, scale);
+}
+
+void MTY_CursorDraw(MTY_Cursor *ctx, MTY_Window window)
+{
+	if (!ctx->image || !ctx->enabled)
+		return;
+	
+    MTY_RenderDesc desc = {0};
+
+	desc.format = MTY_COLOR_FORMAT_RGBA;
+	desc.filter = MTY_FILTER_LINEAR;
+	desc.cropWidth = ctx->width;
+	desc.cropHeight = ctx->height;
+	desc.imageWidth = ctx->width;
+	desc.imageHeight = ctx->width;
+	desc.aspectRatio = (float) ctx->width / (float) ctx->height;
+	desc.blend = true;
+
+	desc.type = MTY_POSITION_FIXED;
+	desc.scale = ctx->scale;
+	desc.imageX = (int32_t) (ctx->x - (ctx->hotX * desc.scale));
+	desc.imageY = (int32_t) (ctx->y - (ctx->hotY * desc.scale));
+
+	MTY_WindowDrawQuad(ctx->app, window, ctx->image, &desc);
+}
+
+void MTY_CursorDestroy(MTY_Cursor **ctx)
+{
+    if (!(*ctx))
+        return;
+
+    if ((*ctx)->image)
+        MTY_Free((*ctx)->image);
+
+    MTY_Free(*ctx);
+    *ctx = NULL;
+}

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3489,6 +3489,166 @@ MTY_EXPORT uint32_t
 MTY_GetVersion(void);
 
 
+//- #module Zoom
+//- #mbrief Image scaling and positioning helper.
+
+typedef struct MTY_Zoom MTY_Zoom;
+
+/// @brief Create a scaling context.
+/// @returns The newly created scaling context.
+MTY_EXPORT MTY_Zoom *
+MTY_ZoomCreate();
+
+/// @brief Update the context with the window and image sizes.
+/// @details Reset and compute initial scaling data for the provided metrics.
+///   This function has not effect in provided metrics are the same as the ones
+///   provided to the previous call of MTY_ZoomUpdate().
+/// @param ctx The MTY_Zoom.
+/// @param windowWidth The window width.
+/// @param windowHeight The window height.
+/// @param imageWidth The image width.
+/// @param imageHeight The image height.
+MTY_EXPORT void 
+MTY_ZoomUpdate(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight, uint32_t imageWidth, uint32_t imageHeight);
+
+/// @brief Apply a scaling data to the context.
+/// @details Update the context according to the provided scaling data.
+/// @param ctx The MTY_Zoom.
+/// @param scaleFactor The new relative scale factor.
+/// @param focusX The new horizontal coordinate of the focal point.
+/// @param focusY The new vertical coordinate of the focal point.
+MTY_EXPORT void 
+MTY_ZoomScale(MTY_Zoom *ctx, float scaleFactor, float focusX, float focusY);
+
+/// @brief Notify the context of a cursor move.
+/// @details Calling this function allows to keep track of the cursor movement.
+///   This is required in relative mode, and recommended in absolute mode to keep
+///   track of the cursor at any time.
+/// @param ctx The MTY_Zoom.
+/// @param x The new X position of the cursor.
+/// @param y The new Y position of the cursor.
+/// @param start Defines the start of a new move gesture.
+MTY_EXPORT void
+MTY_ZoomMove(MTY_Zoom *ctx, int32_t x, int32_t y, bool start);
+
+/// @brief Tranform an absolute X position to one relative to the zoomed area.
+/// @param ctx The MTY_Zoom.
+/// @param value The absolute X position.
+/// @returns The zoom-relative X position.
+MTY_EXPORT int32_t 
+MTY_ZoomTranformX(MTY_Zoom *ctx, int32_t value);
+
+/// @brief Tranform an absolute Y position to one relative to the zoomed area.
+/// @param ctx The MTY_Zoom.
+/// @param value The absolute Y position.
+/// @returns The zoom-relative Y position.
+MTY_EXPORT int32_t 
+MTY_ZoomTranformY(MTY_Zoom *ctx, int32_t value);
+
+/// @brief Get the most recently computed image scale value.
+/// @param ctx The MTY_Zoom.
+/// @returns The computed scale value.
+MTY_EXPORT float 
+MTY_ZoomGetScale(MTY_Zoom *ctx);
+
+/// @brief Get the most recently computed horizontal position of the image. 
+/// @param ctx The MTY_Zoom.
+/// @returns The computed horizontal position.
+MTY_EXPORT int32_t 
+MTY_ZoomGetImageX(MTY_Zoom *ctx);
+
+/// @brief Get the most recently computed vertical position of the image.
+/// @param ctx The MTY_Zoom.
+/// @returns The computed vertical position.
+MTY_EXPORT int32_t 
+MTY_ZoomGetImageY(MTY_Zoom *ctx);
+
+/// @brief Get the current horizontal position of the cursor. 
+/// @param ctx The MTY_Zoom.
+/// @returns The horizontal position, in screen coordinates.
+MTY_EXPORT int32_t 
+MTY_ZoomGetCursorX(MTY_Zoom *ctx);
+
+/// @brief Get the current vertical position of the cursor.
+/// @param ctx The MTY_Zoom.
+/// @returns The vertical position, in screen coordinates.
+MTY_EXPORT int32_t 
+MTY_ZoomGetCursorY(MTY_Zoom *ctx);
+
+/// @brief Check whether a scaling gesture is in progress or not.
+/// @param ctx The MTY_Zoom.
+/// @returns True when scaling, otherwise false.
+MTY_EXPORT bool 
+MTY_ZoomIsScaling(MTY_Zoom *ctx);
+
+/// @brief Set whether a scaling gesture is in progress or not.
+/// @details Scaling status must be set to tell the context all values must be computed.
+///   A disabled state is useful when preparing the context before actually scaling.
+/// @param ctx The MTY_Zoom.
+/// @param scaling True when scaling, otherwise false.
+MTY_EXPORT void 
+MTY_ZoomSetScaling(MTY_Zoom *ctx, bool scaling);
+
+/// @brief Check whether the context treats data as relative inputs or not.
+/// @param ctx The MTY_Zoom.
+/// @returns True when relative, otherwise false.
+MTY_EXPORT bool 
+MTY_ZoomIsRelative(MTY_Zoom *ctx);
+
+/// @brief Set whether the context treats data as relative inputs or not.
+/// @details In relative mode, transform functions return a scaled version of the provided
+///   relative coordinates (e.g. 1 will be tranformed to 0.5 if the current scale factor is 2).
+/// @param ctx The MTY_Zoom.
+/// @param scaling True when relative, otherwise false.
+MTY_EXPORT void
+MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative);
+
+/// @brief Get whether the context uses trackpad mode.
+/// @param ctx The MTY_Zoom.
+/// @returns True if trackpad mode is enabled, false otherwise.
+MTY_EXPORT bool
+MTY_ZoomIsTrackpadEnabled(MTY_Zoom *ctx);
+
+/// @brief Set whether the context uses trackpad mode.
+/// @details Set the behavior the context must adopt when processing data:
+///   * When enabled, the cursor is moved relatively to its previous
+///     position and the zoomed area is panned if the cursor goes out.
+///   * When disabled, the zoomed area does not move and the cursor is
+///     positioned within this area. 
+/// @param ctx The MTY_Zoom.
+/// @param enable True to enable trackpad mode, false otherwise.
+MTY_EXPORT void
+MTY_ZoomEnableTrackpad(MTY_Zoom *ctx, bool enable);
+
+/// @brief Check if the cursor has moved since the previous call.
+/// @param ctx The MTY_Zoom.
+/// @returns True if the cursor has moved, false otherwise.
+MTY_EXPORT bool
+MTY_ZoomHasMoved(MTY_Zoom *ctx);
+
+/// @brief Check if the context recommends to show a cursor.
+/// @details Currently, the context will recommend the show a cursor when the mode is
+///   MTY_INPUT_MODE_TRACKPAD and the context is not relative, and to hide it otherwise.
+/// @param ctx The MTY_Zoom.
+/// @returns True if the cursor should be shown, false otherwise.
+MTY_EXPORT bool 
+MTY_ZoomShouldShowCursor(MTY_Zoom *ctx);
+
+/// @brief Set the scale limits of the context.
+/// @details This must be called before the first call to MTY_ZoomUpdate(). If not, the
+///   change will only have effect after the next context reset, occuring after a window
+///   or image resize. By default, the minimum is 1 (100%) and the maximum is 4 (400%).
+/// @param ctx The MTY_Zoom.
+/// @param min The minimum scaling factor.
+/// @param max The maximum scaling factor.
+MTY_EXPORT void 
+MTY_ZoomSetLimits(MTY_Zoom *ctx, float min, float max);
+
+/// @brief Destroy the scaling context.
+/// @param ctx The MTY_Zoom.
+MTY_EXPORT void 
+MTY_ZoomDestroy(MTY_Zoom **ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -3649,6 +3649,64 @@ MTY_ZoomSetLimits(MTY_Zoom *ctx, float min, float max);
 MTY_EXPORT void 
 MTY_ZoomDestroy(MTY_Zoom **ctx);
 
+
+//- #module Cursor
+//- #mbrief Cursor manipulation and display helper.
+
+typedef struct MTY_Cursor MTY_Cursor;
+
+/// @brief Create a cursor context.
+/// @param ctx The MTY_Cursor.
+/// @returns The newly created cursor context.
+MTY_EXPORT MTY_Cursor *
+MTY_CursorCreate(MTY_App *app);
+
+/// @brief Enable or disable cursor drawing.
+/// @details When disabled, MTY_CursorDraw() has not effect.
+/// @param ctx The MTY_Cursor.
+/// @param enable True to draw the cursor, false otherwise.
+MTY_EXPORT void
+MTY_CursorEnable(MTY_Cursor *ctx, bool enable);
+
+/// @brief Set the hotspot coordinates of the image
+/// @param ctx The MTY_Cursor.
+/// @param hotX The cursor's horizontal hotspot position.
+/// @param hotY The cursor's vertical hotspot position.
+MTY_EXPORT void
+MTY_CursorSetHotspot(MTY_Cursor *ctx, uint16_t hotX, uint16_t hotY);
+
+/// @brief Decompress and set the cursor image.
+/// @param ctx The MTY_Cursor.
+/// @param data The compressed image data.
+/// @param size The size of the image data.
+MTY_EXPORT void
+MTY_CursorSetImage(MTY_Cursor *ctx, const void *data, size_t size);
+
+/// @brief Move the cursor to the specified position.
+/// @param ctx The MTY_Cursor.
+/// @param x The new cursor's horizontal position.
+/// @param y The new cursor's vertical position.
+/// @param scale The scaling factor to apply on the image.
+MTY_EXPORT void
+MTY_CursorMove(MTY_Cursor *ctx, int32_t x, int32_t y, float scale);
+
+/// @brief Move the cursor based on the current MTY_Zoom state.
+/// @param ctx The MTY_Cursor.
+/// @param zoom The MTY_Zoom.
+MTY_EXPORT void
+MTY_CursorMoveFromZoom(MTY_Cursor *ctx, MTY_Zoom *zoom);
+
+/// @brief Draw the cursor on the specified window
+/// @param ctx The MTY_Cursor.
+/// @param window The target window.
+MTY_EXPORT void
+MTY_CursorDraw(MTY_Cursor *ctx, MTY_Window window);
+
+/// @brief Destroy the cursor context.
+/// @param ctx The MTY_Cursor.
+MTY_EXPORT void
+MTY_CursorDestroy(MTY_Cursor **ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -1,0 +1,346 @@
+#include "matoya.h"
+
+// XXX Required because clicks does not always fire on the edges
+#define EDGE_PADDING 1.0f
+
+struct MTY_Zoom {
+	MTY_InputMode mode;
+	bool scaling;
+	bool relative;
+	bool postpone;
+
+	MTY_Point image;
+	MTY_Point image_min;
+	MTY_Point image_max;
+	MTY_Point focus;
+
+	MTY_Point origin;
+	MTY_Point cursor;
+	float margin;
+	float status;
+
+	uint32_t image_w;
+	uint32_t image_h;
+	uint32_t window_w;
+	uint32_t window_h;
+
+	float scale_screen;
+	float scale_screen_min;
+	float scale_screen_max;
+	float scale_image;
+	float scale_image_min;
+	float scale_image_max;
+};
+
+MTY_Zoom *MTY_ZoomCreate() 
+{
+	MTY_Zoom *ctx = MTY_Alloc(1, sizeof(MTY_Zoom));
+
+	ctx->mode = MTY_INPUT_MODE_TOUCHSCREEN;
+
+	ctx->scale_screen = 1;
+	ctx->scale_screen_min = 1;
+	ctx->scale_screen_max = 4;
+
+	return ctx;
+}
+
+static bool mty_zoom_context_initialized(MTY_Zoom *ctx)
+{
+	return ctx && ctx->window_w && ctx->window_h && ctx->image_w && ctx->image_h;
+}
+
+static float mty_zoom_tranform_x(MTY_Zoom *ctx, float value)
+{
+	float offset_x = - ctx->image.x / ctx->scale_screen + ctx->image_min.x;
+	float zoom_w   = ctx->window_w / ctx->scale_screen;
+	float ratio_x  = (float) value / ctx->window_w;
+
+	return offset_x + zoom_w * ratio_x;
+}
+
+static float mty_zoom_tranform_y(MTY_Zoom *ctx, float value)
+{
+	float offset_y = - ctx->image.y / ctx->scale_screen + ctx->image_min.y;
+	float zoom_h   = ctx->window_h / ctx->scale_screen;
+	float ratio_y  = (float) value / ctx->window_h;
+
+	return offset_y + zoom_h * ratio_y;
+}
+
+static void mty_zoom_restrict_image(MTY_Zoom *ctx)
+{
+	float image_scaled_w = ctx->image_w * ctx->scale_image;
+	float image_scaled_h = ctx->image_h * ctx->scale_image;
+
+	if (ctx->image.x > ctx->image_min.x)
+		ctx->image.x = ctx->image_min.x;
+
+	if (ctx->image.y > ctx->image_min.y)
+		ctx->image.y = ctx->image_min.y;
+
+	if (ctx->image.x < ctx->image_max.x - image_scaled_w)
+		ctx->image.x = ctx->image_max.x - image_scaled_w;
+
+	if (ctx->image.y < ctx->image_max.y - image_scaled_h)
+		ctx->image.y = ctx->image_max.y - image_scaled_h;
+}
+
+void MTY_ZoomUpdate(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight, uint32_t imageWidth, uint32_t imageHeight)
+{
+	if (!ctx)
+		return;
+
+	bool same_window = ctx->window_w == windowWidth && ctx->window_h == windowHeight;
+	bool same_image  = ctx->image_w  == imageWidth  && ctx->image_h  == imageHeight;
+	if (same_window && same_image)
+		return;
+
+	ctx->window_w = windowWidth;
+	ctx->window_h = windowHeight;
+	ctx->image_w = imageWidth;
+	ctx->image_h = imageHeight;
+
+	ctx->scale_screen = 1;
+	float scale_w = (float) ctx->window_w / ctx->image_w;
+	float scale_h = (float) ctx->window_h / ctx->image_h;
+	ctx->scale_image = scale_w < scale_h ? scale_w : scale_h;
+
+	ctx->image.x = 0;
+	ctx->image.y = 0;
+	if (scale_w > scale_h) 
+		ctx->image.x = (ctx->window_w - ctx->image_w * ctx->scale_image) / 2.0f;
+	if (scale_w < scale_h) 
+		ctx->image.y = (ctx->window_h - ctx->image_h * ctx->scale_image) / 2.0f;
+
+	ctx->image_min.x = ctx->image.x;
+	ctx->image_min.y = ctx->image.y;
+	ctx->image_max.x = ctx->window_w - ctx->image.x;
+	ctx->image_max.y = ctx->window_h - ctx->image.y;
+
+	ctx->scale_image_min = ctx->scale_image * ctx->scale_screen_min;
+	ctx->scale_image_max = ctx->scale_image * ctx->scale_screen_max;
+
+	ctx->cursor.x = ctx->window_w / 2.0f;
+	ctx->cursor.y = ctx->window_h / 2.0f;
+
+	ctx->margin = (ctx->window_w < ctx->window_h ? ctx->window_w : ctx->window_h) * 0.2f;
+
+	ctx->focus.x = 0;
+	ctx->focus.y = 0;
+}
+
+void MTY_ZoomScale(MTY_Zoom *ctx, float scaleFactor, float focusX, float focusY)
+{
+	if (!mty_zoom_context_initialized(ctx))
+		return;
+
+	if (ctx->scaling) {
+		ctx->image.x += focusX - ctx->focus.x;
+		ctx->image.y += focusY - ctx->focus.y;
+	}
+
+	ctx->focus.x = focusX;
+	ctx->focus.y = focusY;
+
+	ctx->scale_screen *= scaleFactor;
+	ctx->scale_image  *= scaleFactor;
+	
+	if (ctx->scale_screen < ctx->scale_screen_min) {
+		ctx->scale_screen = ctx->scale_screen_min;
+		ctx->scale_image  = ctx->scale_image_min;
+		scaleFactor = 1;
+	}
+
+	if (ctx->scale_screen > ctx->scale_screen_max) {
+		ctx->scale_screen = ctx->scale_screen_max;
+		ctx->scale_image  = ctx->scale_image_max;
+		scaleFactor = 1;
+	}
+
+	ctx->image.x = ctx->focus.x - scaleFactor * (ctx->focus.x - ctx->image.x);
+	ctx->image.y = ctx->focus.y - scaleFactor * (ctx->focus.y - ctx->image.y);
+
+	mty_zoom_restrict_image(ctx);
+
+	if (ctx->scaling) {
+		ctx->cursor.x = mty_zoom_tranform_x(ctx, ctx->window_w / 2.0f);
+		ctx->cursor.y = mty_zoom_tranform_y(ctx, ctx->window_h / 2.0f);
+	}
+}
+
+void MTY_ZoomMove(MTY_Zoom *ctx, int32_t x, int32_t y, bool start)
+{
+	if (!mty_zoom_context_initialized(ctx) || ctx->scaling)
+		return;
+
+	if (ctx->mode == MTY_INPUT_MODE_TOUCHSCREEN) {
+		ctx->cursor.x = mty_zoom_tranform_x(ctx, (float) x);
+		ctx->cursor.y = mty_zoom_tranform_y(ctx, (float) y);
+		return;
+	}
+
+	if (start || ctx->postpone) {
+		ctx->postpone = ctx->relative;
+
+		if (ctx->postpone)
+			return;
+
+		ctx->origin.x = (float) x;
+		ctx->origin.y = (float) y;
+		return;
+	}
+
+	float delta_x = x - ctx->origin.x;
+	float delta_y = y - ctx->origin.y;
+
+	ctx->cursor.x += delta_x / ctx->scale_screen;
+	ctx->cursor.y += delta_y / ctx->scale_screen;
+
+	if (ctx->cursor.x < ctx->image_min.x + EDGE_PADDING)
+		ctx->cursor.x = ctx->image_min.x + EDGE_PADDING;
+
+	if (ctx->cursor.y < ctx->image_min.y + EDGE_PADDING)
+		ctx->cursor.y = ctx->image_min.y + EDGE_PADDING;
+
+	if (ctx->cursor.x > ctx->window_w - ctx->image_min.x - EDGE_PADDING)
+		ctx->cursor.x = ctx->window_w - ctx->image_min.x - EDGE_PADDING;
+
+	if (ctx->cursor.y > ctx->window_h - ctx->image_min.y - EDGE_PADDING)
+		ctx->cursor.y = ctx->window_h - ctx->image_min.y - EDGE_PADDING;
+
+	float left   = mty_zoom_tranform_x(ctx, ctx->margin);
+	float right  = mty_zoom_tranform_x(ctx, ctx->window_w - ctx->margin);
+	float top    = mty_zoom_tranform_y(ctx, ctx->margin);
+	float bottom = mty_zoom_tranform_y(ctx, ctx->window_h - ctx->margin);
+
+	if (delta_x < 0 && ctx->cursor.x < left)
+		ctx->image.x -= delta_x;
+
+	if (delta_x > 0 && ctx->cursor.x > right)
+		ctx->image.x -= delta_x;
+
+	if (delta_y < 0 && ctx->cursor.y < top)
+		ctx->image.y -= delta_y;
+
+	if (delta_y > 0 && ctx->cursor.y > bottom)
+		ctx->image.y -= delta_y;
+
+	mty_zoom_restrict_image(ctx);
+
+	ctx->origin.x = (float) x;
+	ctx->origin.y = (float) y;
+}
+
+int32_t MTY_ZoomTranformX(MTY_Zoom *ctx, int32_t value)
+{
+	if (ctx->relative)
+		return (int32_t) (value / ctx->scale_screen);
+
+	if (ctx->mode == MTY_INPUT_MODE_TRACKPAD)
+		return (int32_t) ctx->cursor.x;
+
+	return (int32_t) mty_zoom_tranform_x(ctx, (float) value);
+}
+
+int32_t MTY_ZoomTranformY(MTY_Zoom *ctx, int32_t value)
+{
+	if (ctx->relative)
+		return (int32_t) (value / ctx->scale_screen);
+
+	if (ctx->mode == MTY_INPUT_MODE_TRACKPAD)
+		return (int32_t) ctx->cursor.y;
+
+	return (int32_t) mty_zoom_tranform_y(ctx, (float) value);
+}
+
+float MTY_ZoomGetScale(MTY_Zoom *ctx)
+{
+	return ctx->scale_image;
+}
+
+int32_t MTY_ZoomGetImageX(MTY_Zoom *ctx)
+{
+	return (int32_t) ctx->image.x;
+}
+
+int32_t MTY_ZoomGetImageY(MTY_Zoom *ctx)
+{
+	return (int32_t) ctx->image.y;
+}
+
+int32_t MTY_ZoomGetCursorX(MTY_Zoom *ctx)
+{
+	float left  = mty_zoom_tranform_x(ctx, 0);
+	float right = mty_zoom_tranform_x(ctx, (float) ctx->window_w);
+
+	return (int32_t) (ctx->window_w * (ctx->cursor.x - left) / (right - left));
+}
+
+int32_t MTY_ZoomGetCursorY(MTY_Zoom *ctx)
+{
+	float top    = mty_zoom_tranform_y(ctx, 0);
+	float bottom = mty_zoom_tranform_y(ctx, (float) ctx->window_h);
+
+	return (int32_t) (ctx->window_h * (ctx->cursor.y - top) / (bottom - top));
+}
+
+bool MTY_ZoomIsScaling(MTY_Zoom *ctx)
+{
+	return ctx->scaling;
+}
+
+void MTY_ZoomSetScaling(MTY_Zoom *ctx, bool scaling)
+{
+	ctx->scaling = scaling;
+}
+
+bool MTY_ZoomIsRelative(MTY_Zoom *ctx)
+{
+	return ctx->relative;
+}
+
+void MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative)
+{
+	ctx->relative = relative;
+}
+
+bool MTY_ZoomIsTrackpadEnabled(MTY_Zoom *ctx)
+{
+	return ctx->mode == MTY_INPUT_MODE_TRACKPAD;
+}
+
+void MTY_ZoomEnableTrackpad(MTY_Zoom *ctx, bool enable)
+{
+	ctx->mode = enable ? MTY_INPUT_MODE_TRACKPAD : MTY_INPUT_MODE_TOUCHSCREEN;
+}
+
+bool MTY_ZoomHasMoved(MTY_Zoom *ctx)
+{
+	float status = ctx->cursor.x + ctx->cursor.y + ctx->image.x + ctx->image.y;
+
+	bool has_moved = status != ctx->status;
+	ctx->status = status;
+
+	return has_moved || ctx->scaling;
+}
+
+bool MTY_ZoomShouldShowCursor(MTY_Zoom *ctx)
+{
+	return ctx->mode == MTY_INPUT_MODE_TRACKPAD && !ctx->relative;
+}
+
+void MTY_ZoomSetLimits(MTY_Zoom *ctx, float min, float max)
+{
+	ctx->scale_screen_min = min;
+	ctx->scale_screen_max = max;
+}
+
+void MTY_ZoomDestroy(MTY_Zoom **ctx)
+{
+	if (!(*ctx))
+		return;
+
+	MTY_Free(*ctx);
+	*ctx = NULL;
+}

--- a/src/zoom.c
+++ b/src/zoom.c
@@ -3,6 +3,8 @@
 // XXX Required because clicks does not always fire on the edges
 #define EDGE_PADDING 1.0f
 
+#define assert(ctx, ...) if (!ctx) return __VA_ARGS__
+
 struct MTY_Zoom {
 	MTY_InputMode mode;
 	bool scaling;
@@ -88,8 +90,7 @@ static void mty_zoom_restrict_image(MTY_Zoom *ctx)
 
 void MTY_ZoomUpdate(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight, uint32_t imageWidth, uint32_t imageHeight)
 {
-	if (!ctx)
-		return;
+	assert(ctx);
 
 	bool same_window = ctx->window_w == windowWidth && ctx->window_h == windowHeight;
 	bool same_image  = ctx->image_w  == imageWidth  && ctx->image_h  == imageHeight;
@@ -132,6 +133,8 @@ void MTY_ZoomUpdate(MTY_Zoom *ctx, uint32_t windowWidth, uint32_t windowHeight, 
 
 void MTY_ZoomScale(MTY_Zoom *ctx, float scaleFactor, float focusX, float focusY)
 {
+	assert(ctx);
+
 	if (!mty_zoom_context_initialized(ctx))
 		return;
 
@@ -171,6 +174,8 @@ void MTY_ZoomScale(MTY_Zoom *ctx, float scaleFactor, float focusX, float focusY)
 
 void MTY_ZoomMove(MTY_Zoom *ctx, int32_t x, int32_t y, bool start)
 {
+	assert(ctx);
+
 	if (!mty_zoom_context_initialized(ctx) || ctx->scaling)
 		return;
 
@@ -234,6 +239,8 @@ void MTY_ZoomMove(MTY_Zoom *ctx, int32_t x, int32_t y, bool start)
 
 int32_t MTY_ZoomTranformX(MTY_Zoom *ctx, int32_t value)
 {
+	assert(ctx, value);
+
 	if (ctx->relative)
 		return (int32_t) (value / ctx->scale_screen);
 
@@ -245,6 +252,8 @@ int32_t MTY_ZoomTranformX(MTY_Zoom *ctx, int32_t value)
 
 int32_t MTY_ZoomTranformY(MTY_Zoom *ctx, int32_t value)
 {
+	assert(ctx, value);
+
 	if (ctx->relative)
 		return (int32_t) (value / ctx->scale_screen);
 
@@ -256,21 +265,29 @@ int32_t MTY_ZoomTranformY(MTY_Zoom *ctx, int32_t value)
 
 float MTY_ZoomGetScale(MTY_Zoom *ctx)
 {
+	assert(ctx, 1);
+
 	return ctx->scale_image;
 }
 
 int32_t MTY_ZoomGetImageX(MTY_Zoom *ctx)
 {
+	assert(ctx, 0);
+
 	return (int32_t) ctx->image.x;
 }
 
 int32_t MTY_ZoomGetImageY(MTY_Zoom *ctx)
 {
+	assert(ctx, 0);
+
 	return (int32_t) ctx->image.y;
 }
 
 int32_t MTY_ZoomGetCursorX(MTY_Zoom *ctx)
 {
+	assert(ctx, 0);
+
 	float left  = mty_zoom_tranform_x(ctx, 0);
 	float right = mty_zoom_tranform_x(ctx, (float) ctx->window_w);
 
@@ -279,6 +296,8 @@ int32_t MTY_ZoomGetCursorX(MTY_Zoom *ctx)
 
 int32_t MTY_ZoomGetCursorY(MTY_Zoom *ctx)
 {
+	assert(ctx, 0);
+
 	float top    = mty_zoom_tranform_y(ctx, 0);
 	float bottom = mty_zoom_tranform_y(ctx, (float) ctx->window_h);
 
@@ -287,36 +306,50 @@ int32_t MTY_ZoomGetCursorY(MTY_Zoom *ctx)
 
 bool MTY_ZoomIsScaling(MTY_Zoom *ctx)
 {
+	assert(ctx, false);
+
 	return ctx->scaling;
 }
 
 void MTY_ZoomSetScaling(MTY_Zoom *ctx, bool scaling)
 {
+	assert(ctx);
+
 	ctx->scaling = scaling;
 }
 
 bool MTY_ZoomIsRelative(MTY_Zoom *ctx)
 {
+	assert(ctx, false);
+
 	return ctx->relative;
 }
 
 void MTY_ZoomSetRelative(MTY_Zoom *ctx, bool relative)
 {
+	assert(ctx);
+
 	ctx->relative = relative;
 }
 
 bool MTY_ZoomIsTrackpadEnabled(MTY_Zoom *ctx)
 {
+	assert(ctx, false);
+
 	return ctx->mode == MTY_INPUT_MODE_TRACKPAD;
 }
 
 void MTY_ZoomEnableTrackpad(MTY_Zoom *ctx, bool enable)
 {
+	assert(ctx);
+
 	ctx->mode = enable ? MTY_INPUT_MODE_TRACKPAD : MTY_INPUT_MODE_TOUCHSCREEN;
 }
 
 bool MTY_ZoomHasMoved(MTY_Zoom *ctx)
 {
+	assert(ctx, false);
+
 	float status = ctx->cursor.x + ctx->cursor.y + ctx->image.x + ctx->image.y;
 
 	bool has_moved = status != ctx->status;
@@ -327,20 +360,26 @@ bool MTY_ZoomHasMoved(MTY_Zoom *ctx)
 
 bool MTY_ZoomShouldShowCursor(MTY_Zoom *ctx)
 {
+	assert(ctx, false);
+
 	return ctx->mode == MTY_INPUT_MODE_TRACKPAD && !ctx->relative;
 }
 
 void MTY_ZoomSetLimits(MTY_Zoom *ctx, float min, float max)
 {
+	assert(ctx);
+
 	ctx->scale_screen_min = min;
 	ctx->scale_screen_max = max;
 }
 
-void MTY_ZoomDestroy(MTY_Zoom **ctx)
+void MTY_ZoomDestroy(MTY_Zoom **zoom)
 {
-	if (!(*ctx))
+	if (!zoom || !*zoom)
 		return;
 
-	MTY_Free(*ctx);
-	*ctx = NULL;
+	MTY_Zoom *ctx = *zoom;
+
+	MTY_Free(ctx);
+	*zoom = NULL;
 }


### PR DESCRIPTION
* `MTY_Zoom` module: This module provides out-of-the-box coordinates conversion and cursor positioning, based of on the `MTY_EVENT_MOTION` and `MTY_EVENT_SCALE` events' data. It supports multiple modes:

    * `MTY_INPUT_MODE_TOUCHSCREEN`: In this mode, the cursor position is directly transformed from the absolute screen coordinates to the zoomed viewport, and the image is never moved.
    * `MTY_INPUT_MODE_TRACKPAD`: In this mode, the cursor position is computed relatively from motion events, and the image is moved in case the cursor hits the borders of the zoomed viewport.
    * Relative: This special mode is made for when the input data are relative and the cursor position must not be converted.

* `MTY_Cursor` module: This helper module allows to create, setup and draw a cursor. This is basically a wrapper around `MTY_WindowDrawQuad`.