### PR TITLE
[android-zoom] Add clearing and blending capabilities to DrawQuad functions

### DIFF
--- a/src/gfx/gl.c
+++ b/src/gfx/gl.c
@@ -287,8 +287,17 @@ bool mty_gl_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 	if (_dest)
 		glBindFramebuffer(GL_FRAMEBUFFER, _dest);
 
+	// Blending capability
+	if (desc->blend) {
+		glEnable(GL_BLEND);
+		glBlendEquation(GL_FUNC_ADD);
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+	} else {
+		glDisable(GL_BLEND);
+	}
+	
 	// Context state, set vertex and fragment shaders
-	glDisable(GL_BLEND);
 	glDisable(GL_CULL_FACE);
 	glDisable(GL_DEPTH_TEST);
 	glDisable(GL_SCISSOR_TEST);

--- a/src/gfx/gl.c
+++ b/src/gfx/gl.c
@@ -303,8 +303,10 @@ bool mty_gl_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 	glVertexAttribPointer(ctx->loc_uv,  2, GL_FLOAT, GL_FALSE, 4 * sizeof(GLfloat), (void *) (2 * sizeof(GLfloat)));
 
 	// Clear
-	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-	glClear(GL_COLOR_BUFFER_BIT);
+	if (desc->clear) {
+		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+		glClear(GL_COLOR_BUFFER_BIT);
+	}
 
 	// Fragment shader
 	for (uint8_t x = 0; x < GL_NUM_STAGING; x++) {

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -116,6 +116,7 @@ typedef struct {
 	float scale;            ///< Multiplier applied to the dimensions of the image, producing an
 	                        ///<   minimized or magnified image. This can be set to 0
 	                        ///<   if unnecessary.
+	bool clear;             ///< Should clear the window before drawing the quad.
 } MTY_RenderDesc;
 
 /// @brief A point with an `x` and `y` coordinate.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -117,6 +117,8 @@ typedef struct {
 	                        ///<   minimized or magnified image. This can be set to 0
 	                        ///<   if unnecessary.
 	bool clear;             ///< Should clear the window before drawing the quad.
+	bool blend;             ///< Should enable blending capability when drawing the quad.
+	                        ///<   Note: This is currently not supported in D3D12 and Metal.
 } MTY_RenderDesc;
 
 /// @brief A point with an `x` and `y` coordinate.

--- a/src/unix/apple/gfx/metal.m
+++ b/src/unix/apple/gfx/metal.m
@@ -253,8 +253,10 @@ bool mty_metal_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 	// Begin render pass
 	MTLRenderPassDescriptor *rpd = [MTLRenderPassDescriptor new];
 	rpd.colorAttachments[0].texture = _dest;
-	rpd.colorAttachments[0].clearColor = MTLClearColorMake(0.0, 0.0, 0.0, 1.0);
-	rpd.colorAttachments[0].loadAction = MTLLoadActionClear;
+	if (desc->clear) {
+		rpd.colorAttachments[0].clearColor = MTLClearColorMake(0.0, 0.0, 0.0, 1.0);
+		rpd.colorAttachments[0].loadAction = MTLLoadActionClear;
+	}
 	rpd.colorAttachments[0].storeAction = MTLStoreActionStore;
 
 	id<MTLCommandBuffer> cb = [cq commandBuffer];

--- a/src/windows/gfx/d3d11.c
+++ b/src/windows/gfx/d3d11.c
@@ -389,8 +389,10 @@ bool mty_d3d11_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 		ID3D11DeviceContext_OMSetRenderTargets(_context, 1, &rtv, NULL);
 
-		FLOAT clear_color[4] = {0.0f, 0.0f, 0.0f, 1.0f};
-		ID3D11DeviceContext_ClearRenderTargetView(_context, rtv, clear_color);
+		if (desc->clear) {
+			FLOAT clear_color[4] = {0.0f, 0.0f, 0.0f, 1.0f};
+			ID3D11DeviceContext_ClearRenderTargetView(_context, rtv, clear_color);
+		}
 	}
 
 	// Vertex shader

--- a/src/windows/gfx/d3d11.c
+++ b/src/windows/gfx/d3d11.c
@@ -53,6 +53,7 @@ struct d3d11 {
 	ID3D11SamplerState *ss_nearest;
 	ID3D11SamplerState *ss_linear;
 	ID3D11RasterizerState *rs;
+	ID3D11BlendState *bs;
 	ID3D11DepthStencilState *dss;
 };
 
@@ -165,6 +166,22 @@ struct gfx *mty_d3d11_create(MTY_Device *device)
 	e = ID3D11Device_CreateRasterizerState(_device, &rdesc, &ctx->rs);
 	if (e != S_OK) {
 		MTY_Log("'ID3D11Device_CreateRasterizerState' failed with HRESULT 0x%X", e);
+		goto except;
+	}
+
+	D3D11_BLEND_DESC bdesc = {0};
+	bdesc.AlphaToCoverageEnable = false;
+	bdesc.RenderTarget[0].BlendEnable = true;
+	bdesc.RenderTarget[0].SrcBlend = D3D11_BLEND_SRC_ALPHA;
+	bdesc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
+	bdesc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
+	bdesc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
+	bdesc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
+	bdesc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
+	bdesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+	e = ID3D11Device_CreateBlendState(_device, &bdesc, &ctx->bs);
+	if (e != S_OK) {
+		MTY_Log("'ID3D11Device_CreateBlendState' failed with HRESULT 0x%X", e);
 		goto except;
 	}
 
@@ -404,7 +421,15 @@ bool mty_d3d11_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 	ID3D11DeviceContext_IASetIndexBuffer(_context, ctx->ib, DXGI_FORMAT_R32_UINT, 0);
 	ID3D11DeviceContext_IASetInputLayout(_context, ctx->il);
 	ID3D11DeviceContext_IASetPrimitiveTopology(_context, D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-	ID3D11DeviceContext_OMSetBlendState(_context, NULL, NULL, 0xFFFFFFFF);
+
+	if (desc->blend) {
+		const float blend_factor[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+		ID3D11DeviceContext_OMSetBlendState(_context, ctx->bs, blend_factor, 0xFFFFFFFF);
+
+	} else {
+		ID3D11DeviceContext_OMSetBlendState(_context, NULL, NULL, 0xFFFFFFFF);
+	}
+
 	ID3D11DeviceContext_OMSetDepthStencilState(_context, ctx->dss, 0);
 	ID3D11DeviceContext_RSSetState(_context, ctx->rs);
 
@@ -462,6 +487,9 @@ void mty_d3d11_destroy(struct gfx **gfx)
 
 	if (ctx->rs)
 		ID3D11RasterizerState_Release(ctx->rs);
+
+	if (ctx->bs)
+		ID3D11BlendState_Release(ctx->bs);
 
 	if (ctx->dss)
 		ID3D11DepthStencilState_Release(ctx->dss);

--- a/src/windows/gfx/d3d12.c
+++ b/src/windows/gfx/d3d12.c
@@ -576,8 +576,10 @@ bool mty_d3d12_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 	if (_dest) {
 		ID3D12GraphicsCommandList_OMSetRenderTargets(cl, 1, _dest, FALSE, NULL);
 
-		const float color[4] = {0.0f, 0.0f, 0.0f, 1.0f};
-		ID3D12GraphicsCommandList_ClearRenderTargetView(cl, *_dest, color, 0, NULL);
+		if (desc->clear) {
+			const float color[4] = {0.0f, 0.0f, 0.0f, 1.0f};
+			ID3D12GraphicsCommandList_ClearRenderTargetView(cl, *_dest, color, 0, NULL);
+		}
 	}
 
 	// Set up pipeline

--- a/src/windows/gfx/d3d9.c
+++ b/src/windows/gfx/d3d9.c
@@ -358,6 +358,14 @@ bool mty_d3d9_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 		goto except;
 	}
 
+	if (desc->blend) {
+		IDirect3DDevice9_SetRenderState(_device, D3DRS_ALPHABLENDENABLE, true);
+		IDirect3DDevice9_SetRenderState(_device, D3DRS_ALPHATESTENABLE, false);
+		IDirect3DDevice9_SetRenderState(_device, D3DRS_BLENDOP, D3DBLENDOP_ADD);
+		IDirect3DDevice9_SetRenderState(_device, D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
+		IDirect3DDevice9_SetRenderState(_device, D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
+	}
+
 	// D3D9 half texel fix
 	float texel_offset[4] = {0};
 	texel_offset[0] = -1.0f / (float) vp.Width;

--- a/src/windows/gfx/d3d9.c
+++ b/src/windows/gfx/d3d9.c
@@ -306,10 +306,12 @@ bool mty_d3d9_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 			goto except;
 		}
 
-		e = IDirect3DDevice9_Clear(_device, 0, NULL, D3DCLEAR_TARGET, D3DCOLOR_XRGB(0, 0, 0), 1.0f, 0);
-		if (e != D3D_OK) {
-			MTY_Log("'IDirect3DDevice9_Clear' failed with HRESULT 0x%X", e);
-			goto except;
+		if (desc->clear) {
+			e = IDirect3DDevice9_Clear(_device, 0, NULL, D3DCLEAR_TARGET, D3DCOLOR_XRGB(0, 0, 0), 1.0f, 0);
+			if (e != D3D_OK) {
+				MTY_Log("'IDirect3DDevice9_Clear' failed with HRESULT 0x%X", e);
+				goto except;
+			}
 		}
 	}
 


### PR DESCRIPTION
Required to draw a cursor on top of an existing drawn quad.

* Draw multiple quads before presenting: A `clear` property has been added to `MTY_DrawDesc` to trigger screen clearing. The window will only be cleared if this property is set, and therefore allows for multiple drawings. A typical usage is to clear on the first `MTY_WindowDrawQuad` call in the application loop.
* Blending support when drawing quads: By setting the `blend` property on `MTY_DrawDesc`, blending will be enabled for the corresponding drawings, which allows to make use of the frame's alpha channel if available. This is currently only supported with `MTY_GFX_GL`, `MTY_GFX_D3D9` and `MTY_GFX_D3D11`.