### PR TITLE
Add Wintab-compatible device support on Windows applications

### DIFF
--- a/deps/wintab/MSGPACK.H
+++ b/deps/wintab/MSGPACK.H
@@ -1,0 +1,34 @@
+/*----------------------------------------------------------------------------s
+	NAME
+		MSGPACK.H
+
+	PURPOSE
+		Selected message unpacking macros from windowsx.h
+		to circumvent compile-time memory headaches.
+
+	COPYRIGHT
+		This file is Copyright (c) Wacom Company, Ltd. 2020 All Rights Reserved
+		with portions copyright 1991-1998 by LCS/Telegraphics.
+
+		The text and information contained in this file may be freely used,
+		copied, or distributed without compensation or licensing restrictions.
+---------------------------------------------------------------------------- */
+#pragma once
+
+#ifdef WIN32
+#define GET_WM_ACTIVATE_STATE(wp, lp)           LOWORD(wp)
+#define GET_WM_COMMAND_ID(wp, lp)               LOWORD(wp)
+#define GET_WM_COMMAND_HWND(wp, lp)             (HWND)(lp)
+#define GET_WM_COMMAND_CMD(wp, lp)              HIWORD(wp)
+#define FORWARD_WM_COMMAND(hwnd, id, hwndCtl, codeNotify, fn) \
+    (void)(fn)((hwnd), WM_COMMAND, MAKEWPARAM((UINT)(id),(UINT)(codeNotify)), (LPARAM)(HWND)(hwndCtl))
+/* -------------------------------------------------------------------------- */
+#else
+#define GET_WM_ACTIVATE_STATE(wp, lp)               (wp)
+#define GET_WM_COMMAND_ID(wp, lp)                   (wp)
+#define GET_WM_COMMAND_HWND(wp, lp)                 (HWND)LOWORD(lp)
+#define GET_WM_COMMAND_CMD(wp, lp)                  HIWORD(lp)
+#define FORWARD_WM_COMMAND(hwnd, id, hwndCtl, codeNotify, fn) \
+    (void)(fn)((hwnd), WM_COMMAND, (WPARAM)(int)(id), MAKELPARAM((UINT)(hwndCtl), (codeNotify)))
+/* -------------------------------------------------------------------------- */
+#endif

--- a/deps/wintab/PKTDEF.H
+++ b/deps/wintab/PKTDEF.H
@@ -1,0 +1,269 @@
+/*----------------------------------------------------------------------------s
+	NAME
+		PKTDEF.H
+
+	PURPOSE
+		Used to help construct a Wintab PACKETDATA definition the application 
+		uses to specify what data to receive in a Wintab data packet
+
+	COPYRIGHT
+		This file is Copyright (c) Wacom Company, Ltd. 2020 All Rights Reserved
+		with portions copyright 1991-1998 by LCS/Telegraphics.
+
+		The text and information contained in this file may be freely used,
+		copied, or distributed without compensation or licensing restrictions.
+---------------------------------------------------------------------------- */
+#pragma once
+
+/*------------------------------------------------------------------------------
+
+How to use pktdef.h:
+
+1. Include wintab.h
+2. if using just one packet format:
+	a. Define PACKETDATA and PACKETMODE as or'ed combinations of WTPKT bits
+	   (use the PK_* identifiers).
+	b. Include pktdef.h.
+	c. The generated structure typedef will be called PACKET.  Use PACKETDATA
+	   and PACKETMODE to fill in the LOGCONTEXT structure.
+3. If using multiple packet formats, for each one:
+	a. Define PACKETNAME. Its text value will be a prefix for this packet's
+	   parameters and names.
+	b. Define <PACKETNAME>PACKETDATA and <PACKETNAME>PACKETMODE similar to
+	   2.a. above.
+	c. Include pktdef.h.
+	d. The generated structure typedef will be called
+	   <PACKETNAME>PACKET. Compare with 2.c. above and example #2 below.
+4. If using extension data for extensions that report thier data in the packet,
+   do the following additional steps for each extension:
+	a. Before including pktdef.h, define <PACKETNAME>PACKET<EXTENSION>
+	   as either PKEXT_ABSOLUTE or PKEXT_RELATIVE.
+	b. The generated structure typedef will contain a field for the
+	   extension data.
+	c. Scan the WTI_EXTENSION categories to find the extension's
+	   packet mask bit.
+	d. OR the packet mask bit with <PACKETNAME>PACKETDATA and use the
+	   result in the lcPktData field of the LOGCONTEXT structure.
+	e. If <PACKETNAME>PACKET<EXTENSION> was PKEXT_RELATIVE, OR the
+	   packet mask bit with <PACKETNAME>PACKETMODE and use the result
+	   in the lcPktMode field of the LOGCONTEXT structure.
+5. If using extension data for extensions that report thier data in the extensions packet,
+   do the following additional steps for each extension:
+	a. Before including pktdef.h, define <PACKETNAME>PACKET<EXTENSION> as PKEXT_ABSOLUTE.
+	b. The generated extension structure typedef will contain a field for the
+	   extension data.
+	c. Call WTExtSet to activate the extention.  Use the context id in the WT_PACKETEXT
+	   message to retrieve the extension data <PACKETNAME>PACKETEXT.
+
+
+Example #1.	-- single packet format
+
+#include <wintab.h>
+#define PACKETDATA	PK_X | PK_Y | PK_BUTTONS	/@ x, y, buttons @/
+#define PACKETMODE	PK_BUTTONS					/@ buttons relative mode @/
+#include <pktdef.h>
+...
+	lc.lcPktData = PACKETDATA;
+	lc.lcPktMode = PACKETMODE;
+
+Example #2. -- multiple formats
+
+#include <wintab.h>
+#define PACKETNAME		MOE
+#define MOEPACKETDATA	PK_X | PK_Y | PK_BUTTONS	/@ x, y, buttons @/
+#define MOEPACKETMODE	PK_BUTTONS					/@ buttons relative mode @/
+#include <pktdef.h>
+#define PACKETNAME		LARRY
+#define LARRYPACKETDATA	PK_Y | PK_Z | PK_BUTTONS	/@ y, z, buttons @/
+#define LARRYPACKETMODE	PK_BUTTONS					/@ buttons relative mode @/
+#include <pktdef.h>
+#define PACKETNAME		CURLY
+#define CURLYPACKETDATA	PK_X | PK_Z | PK_BUTTONS	/@ x, z, buttons @/
+#define CURLYPACKETMODE	PK_BUTTONS					/@ buttons relative mode @/
+#include <pktdef.h>
+...
+	lcMOE.lcPktData = MOEPACKETDATA;
+	lcMOE.lcPktMode = MOEPACKETMODE;
+...
+	lcLARRY.lcPktData = LARRYPACKETDATA;
+	lcLARRY.lcPktMode = LARRYPACKETMODE;
+...
+	lcCURLY.lcPktData = CURLYPACKETDATA;
+	lcCURLY.lcPktMode = CURLYPACKETMODE;
+
+Example #3. -- extension packet data "XFOO".
+	
+#include <wintab.h>
+#define PACKETDATA	PK_X | PK_Y | PK_BUTTONS	/@ x, y, buttons @/
+#define PACKETMODE	PK_BUTTONS					/@ buttons relative mode @/
+#define PACKETXFOO	PKEXT_ABSOLUTE				/@ XFOO absolute mode @/
+#include <pktdef.h>
+...
+UINT ScanExts(UINT wTag)
+{
+	UINT i;
+	UINT wScanTag;
+
+	/@ scan for wTag's info category. @/
+	for (i = 0; WTInfo(WTI_EXTENSIONS + i, EXT_TAG, &wScanTag); i++) {
+		 if (wTag == wScanTag) {
+			/@ return category offset from WTI_EXTENSIONS. @/
+			return i;
+		}
+	}
+	/@ return error code. @/
+	return 0xFFFF;
+}
+...
+	lc.lcPktData = PACKETDATA;
+	lc.lcPktMode = PACKETMODE;
+#ifdef PACKETXFOO
+	categoryXFOO = ScanExts(WTX_XFOO);
+	WTInfo(WTI_EXTENSIONS + categoryXFOO, EXT_MASK, &maskXFOO);
+	lc.lcPktData |= maskXFOO;
+#if PACKETXFOO == PKEXT_RELATIVE
+	lc.lcPktMode |= maskXFOO;
+#endif
+#endif
+	WTOpen(hWnd, &lc, TRUE);
+
+
+------------------------------------------------------------------------------*/
+#ifdef __cplusplus
+extern "C" {
+#endif	/* __cplusplus */
+
+#ifndef PACKETNAME
+	/* if no packet name prefix */
+	#define __PFX(x)	x
+	#define __IFX(x,y)	x ## y
+#else
+	/* add prefixes and infixes to packet format names */
+	#define __PFX(x)		__PFX2(PACKETNAME,x)
+	#define __PFX2(p,x)		__PFX3(p,x)
+	#define __PFX3(p,x)		p ## x
+	#define __IFX(x,y)		__IFX2(x,PACKETNAME,y)
+	#define __IFX2(x,i,y)	__IFX3(x,i,y)
+	#define __IFX3(x,i,y)	x ## i ## y
+#endif
+
+#define __SFX2(x,s)		__SFX3(x,s)
+#define __SFX3(x,s)		x ## s
+
+#define __TAG  	__IFX(tag,PACKET)
+#define __TYPES	__PFX(PACKET), * __IFX(P,PACKET), NEAR * __IFX(NP,PACKET), FAR * __IFX(LP,PACKET)
+
+#define __TAGE  	__IFX(tag,PACKETEXT)
+#define __TYPESE	__PFX(PACKETEXT), * __IFX(P,PACKETEXT), NEAR * __IFX(NP,PACKETEXT), FAR * __IFX(LP,PACKETEXT)
+
+#define __DATA		(__PFX(PACKETDATA))
+#define __MODE		(__PFX(PACKETMODE))
+#define __EXT(x)	__SFX2(__PFX(PACKET),x)
+
+
+typedef struct __TAG {
+	#if (__DATA & PK_CONTEXT)
+		HCTX			pkContext;
+	#endif
+	#if (__DATA & PK_STATUS)
+		UINT			pkStatus;
+	#endif
+	#if (__DATA & PK_TIME)
+		DWORD			pkTime;
+	#endif
+	#if (__DATA & PK_CHANGED)
+		WTPKT			pkChanged;
+	#endif
+	#if (__DATA & PK_SERIAL_NUMBER)
+		UINT			pkSerialNumber;
+	#endif
+	#if (__DATA & PK_CURSOR)
+		UINT			pkCursor;
+	#endif
+	#if (__DATA & PK_BUTTONS)
+		DWORD			pkButtons;
+	#endif
+	#if (__DATA & PK_X)
+		LONG			pkX;
+	#endif
+	#if (__DATA & PK_Y)
+		LONG			pkY;
+	#endif
+	#if (__DATA & PK_Z)
+		LONG			pkZ;
+	#endif
+	#if (__DATA & PK_NORMAL_PRESSURE)
+		#if (__MODE & PK_NORMAL_PRESSURE)
+			/* relative */
+			int			pkNormalPressure;
+		#else
+			/* absolute */
+			UINT		pkNormalPressure;
+		#endif
+	#endif
+	#if (__DATA & PK_TANGENT_PRESSURE)
+		#if (__MODE & PK_TANGENT_PRESSURE)
+			/* relative */
+			int			pkTangentPressure;
+		#else
+			/* absolute */
+			UINT		pkTangentPressure;
+		#endif
+	#endif
+	#if (__DATA & PK_ORIENTATION)
+		ORIENTATION		pkOrientation;
+	#endif
+	#if (__DATA & PK_ROTATION)
+		ROTATION		pkRotation; /* 1.1 */
+	#endif
+
+#ifndef NOWTEXTENSIONS
+	/* extensions begin here. */
+	#if (__EXT(FKEYS) == PKEXT_RELATIVE) || (__EXT(FKEYS) == PKEXT_ABSOLUTE)
+		UINT			pkFKeys;
+	#endif
+	#if (__EXT(TILT) == PKEXT_RELATIVE) || (__EXT(TILT) == PKEXT_ABSOLUTE)
+		TILT			pkTilt;
+	#endif
+#endif
+
+} __TYPES ;
+
+#ifndef NOWTEXTENSIONS
+typedef struct __TAGE {
+	EXTENSIONBASE	pkBase;
+
+	#if (__EXT(EXPKEYS) == PKEXT_RELATIVE) || (__EXT(EXPKEYS) == PKEXT_ABSOLUTE)
+		EXPKEYSDATA pkExpKeys; /* 1.4 */
+	#endif
+	#if (__EXT(TOUCHSTRIP) == PKEXT_RELATIVE) || (__EXT(TOUCHSTRIP) == PKEXT_ABSOLUTE)
+		SLIDERDATA	pkTouchStrip; /* 1.4 */
+	#endif
+	#if (__EXT(TOUCHRING) == PKEXT_RELATIVE) || (__EXT(TOUCHRING) == PKEXT_ABSOLUTE)
+		SLIDERDATA	pkTouchRing; /* 1.4 */
+	#endif
+
+} __TYPESE ;
+#endif
+
+#undef PACKETNAME
+#undef __TAG
+#undef __TAGE
+#undef __TAG2
+#undef __TYPES
+#undef __TYPESE
+#undef __TYPES2
+#undef __DATA
+#undef __MODE
+#undef __PFX
+#undef __PFX2
+#undef __PFX3
+#undef __IFX
+#undef __IFX2
+#undef __IFX3
+#undef __SFX2
+#undef __SFX3
+
+#ifdef __cplusplus
+}
+#endif	/* __cplusplus */

--- a/deps/wintab/WINTAB.H
+++ b/deps/wintab/WINTAB.H
@@ -1,0 +1,922 @@
+/*----------------------------------------------------------------------------s
+	NAME
+		WINTAB.H
+
+	PURPOSE
+		Definitions used to implement a Wintab application according to the 
+		latest Wintab API specification (1.4).
+		
+		Can be used to build 32bit and 64bit applications.
+
+	COPYRIGHT
+		This file is Copyright (c) Wacom Company, Ltd. 2020 All Rights Reserved
+		with portions copyright 1991-1998 by LCS/Telegraphics.
+
+		The text and information contained in this file may be freely used,
+		copied, or distributed without compensation or licensing restrictions.
+---------------------------------------------------------------------------- */
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif	/* __cplusplus */
+
+/* -------------------------------------------------------------------------- */
+/* Messages */
+#ifndef NOWTMESSAGES
+
+	#define WT_DEFBASE			0x7FF0
+	#define WT_MAXOFFSET			0xF
+
+	#define _WT_PACKET(b)		((b)+0)
+	#define _WT_CTXOPEN(b)		((b)+1)
+	#define _WT_CTXCLOSE(b)		((b)+2)
+	#define _WT_CTXUPDATE(b)	((b)+3)
+	#define _WT_CTXOVERLAP(b)	((b)+4)
+	#define _WT_PROXIMITY(b)	((b)+5)
+	#define _WT_INFOCHANGE(b)	((b)+6)
+	#define _WT_CSRCHANGE(b)	((b)+7) /* 1.1 */
+	#define _WT_PACKETEXT(b)	((b)+8) /* 1.4 */
+	#define _WT_MAX(b)			((b)+WT_MAXOFFSET)
+	
+	#define WT_PACKET				_WT_PACKET(WT_DEFBASE)
+	#define WT_CTXOPEN			_WT_CTXOPEN(WT_DEFBASE)
+	#define WT_CTXCLOSE			_WT_CTXCLOSE(WT_DEFBASE)
+	#define WT_CTXUPDATE			_WT_CTXUPDATE(WT_DEFBASE)
+	#define WT_CTXOVERLAP		_WT_CTXOVERLAP(WT_DEFBASE)
+	#define WT_PROXIMITY			_WT_PROXIMITY(WT_DEFBASE)
+	#define WT_INFOCHANGE		_WT_INFOCHANGE(WT_DEFBASE)
+	#define WT_CSRCHANGE			_WT_CSRCHANGE(WT_DEFBASE) /* 1.1 */
+	#define WT_PACKETEXT			_WT_PACKETEXT(WT_DEFBASE) /* 1.4 */
+	#define WT_MAX					_WT_MAX(WT_DEFBASE)
+
+#endif
+
+/* -------------------------------------------------------------------------- */
+/* -------------------------------------------------------------------------- */
+/* Data Types */
+
+/* -------------------------------------------------------------------------- */
+/* COMMON DATA DEFS */
+
+DECLARE_HANDLE(HMGR);		/* manager handle */
+DECLARE_HANDLE(HCTX);		/* context handle */
+DECLARE_HANDLE(HWTHOOK);	/* hook handle */
+
+typedef DWORD WTPKT;			/* packet mask */
+
+
+#ifndef NOWTPKT
+
+	/* WTPKT bits */
+	#define PK_CONTEXT				0x0001	/* reporting context */
+	#define PK_STATUS					0x0002	/* status bits */
+	#define PK_TIME					0x0004	/* time stamp */
+	#define PK_CHANGED				0x0008	/* change bit vector */
+	#define PK_SERIAL_NUMBER		0x0010	/* packet serial number */
+	#define PK_CURSOR					0x0020	/* reporting cursor */
+	#define PK_BUTTONS				0x0040	/* button information */
+	#define PK_X						0x0080	/* x axis */
+	#define PK_Y						0x0100	/* y axis */
+	#define PK_Z						0x0200	/* z axis */
+	#define PK_NORMAL_PRESSURE		0x0400	/* normal or tip pressure */
+	#define PK_TANGENT_PRESSURE	0x0800	/* tangential or barrel pressure */
+	#define PK_ORIENTATION			0x1000	/* orientation info: tilts */
+	#define PK_ROTATION				0x2000	/* rotation info; 1.1 */
+
+#endif
+
+typedef DWORD FIX32;				/* fixed-point arithmetic type */
+
+#ifndef NOFIX32
+	#define INT(x)			HIWORD(x)
+	#define FRAC(x)		LOWORD(x)
+
+	#define CASTFIX32(x)	((FIX32)((x)*65536L))
+
+	#define ROUND(x)		(INT(x) + (FRAC(x) > (WORD)0x8000))
+
+	#define FIX_MUL(c, a, b)							\
+		(c = (((DWORD)FRAC(a) * FRAC(b)) >> 16) +	\
+			(DWORD)INT(a) * FRAC(b) +					\
+			(DWORD)INT(b) * FRAC(a) +					\
+			((DWORD)INT(a) * INT(b) << 16))
+
+	#ifdef _WINDLL
+		#define FIX_DIV_SC static
+	#else
+		#define FIX_DIV_SC
+	#endif
+
+	#define FIX_DIV(c, a, b)						\
+		{													\
+			FIX_DIV_SC DWORD temp, rem, btemp;	\
+															\
+			/* fraction done bytewise */			\
+			temp = ((a / b) << 16);					\
+			rem = a % b;								\
+			btemp = b;									\
+			if (INT(btemp) < 256) {					\
+				rem <<= 8;								\
+			}												\
+			else {										\
+				btemp >>= 8;							\
+			}												\
+			temp += ((rem / btemp) << 8);			\
+			rem %= btemp;								\
+			rem <<= 8;									\
+			temp += rem / btemp;						\
+			c = temp;									\
+		}
+#endif
+
+/* -------------------------------------------------------------------------- */
+/* INFO DATA DEFS */
+
+#ifndef NOWTINFO
+
+#ifndef NOWTAXIS
+
+typedef struct tagAXIS {
+	LONG	axMin;
+	LONG	axMax;
+	UINT	axUnits;
+	FIX32	axResolution;
+} AXIS, *PAXIS, NEAR *NPAXIS, FAR *LPAXIS;
+
+	/* unit specifiers */
+	#define TU_NONE			0
+	#define TU_INCHES		1
+	#define TU_CENTIMETERS	2
+	#define TU_CIRCLE		3
+
+#endif
+
+#ifndef NOWTSYSBUTTONS
+
+/* system button assignment values */
+#define SBN_NONE			0x00
+#define SBN_LCLICK		0x01
+#define SBN_LDBLCLICK	0x02
+#define SBN_LDRAG			0x03
+#define SBN_RCLICK		0x04
+#define SBN_RDBLCLICK	0x05
+#define SBN_RDRAG			0x06
+#define SBN_MCLICK		0x07
+#define SBN_MDBLCLICK	0x08
+#define SBN_MDRAG			0x09
+/* for Pen Windows */
+#define SBN_PTCLICK		0x10
+#define SBN_PTDBLCLICK	0x20
+#define SBN_PTDRAG		0x30
+#define SBN_PNCLICK		0x40
+#define SBN_PNDBLCLICK	0x50
+#define SBN_PNDRAG		0x60
+#define SBN_P1CLICK		0x70
+#define SBN_P1DBLCLICK	0x80
+#define SBN_P1DRAG		0x90
+#define SBN_P2CLICK		0xA0
+#define SBN_P2DBLCLICK	0xB0
+#define SBN_P2DRAG		0xC0
+#define SBN_P3CLICK		0xD0
+#define SBN_P3DBLCLICK	0xE0
+#define SBN_P3DRAG		0xF0
+
+#endif
+
+#ifndef NOWTCAPABILITIES
+
+/* hardware capabilities */
+#define HWC_INTEGRATED		0x0001
+#define HWC_TOUCH				0x0002
+#define HWC_HARDPROX			0x0004
+#define HWC_PHYSID_CURSORS	0x0008 /* 1.1 */
+#endif
+
+#ifndef NOWTIFC
+
+#ifndef NOWTCURSORS
+
+/* cursor capabilities */
+#define CRC_MULTIMODE	0x0001 /* 1.1 */
+#define CRC_AGGREGATE	0x0002 /* 1.1 */
+#define CRC_INVERT		0x0004 /* 1.1 */
+
+#endif 
+
+/* info categories */
+#define WTI_INTERFACE		1
+	#define IFC_WINTABID			1
+	#define IFC_SPECVERSION		2
+	#define IFC_IMPLVERSION		3
+	#define IFC_NDEVICES			4
+	#define IFC_NCURSORS			5
+	#define IFC_NCONTEXTS		6
+	#define IFC_CTXOPTIONS		7
+	#define IFC_CTXSAVESIZE		8
+	#define IFC_NEXTENSIONS		9
+	#define IFC_NMANAGERS		10
+	#define IFC_MAX				10
+
+
+#endif
+
+#ifndef NOWTSTATUS
+
+#define WTI_STATUS			2
+	#define STA_CONTEXTS			1
+	#define STA_SYSCTXS			2
+	#define STA_PKTRATE			3
+	#define STA_PKTDATA			4
+	#define STA_MANAGERS			5
+	#define STA_SYSTEM			6
+	#define STA_BUTTONUSE		7
+	#define STA_SYSBTNUSE		8
+	#define STA_MAX				8
+
+#endif
+
+#ifndef NOWTDEFCONTEXT
+
+#define WTI_DEFCONTEXT	3
+#define WTI_DEFSYSCTX	4
+#define WTI_DDCTXS		400 /* 1.1 */
+#define WTI_DSCTXS		500 /* 1.1 */
+	#define CTX_NAME			1
+	#define CTX_OPTIONS		2
+	#define CTX_STATUS		3
+	#define CTX_LOCKS			4
+	#define CTX_MSGBASE		5
+	#define CTX_DEVICE		6
+	#define CTX_PKTRATE		7
+	#define CTX_PKTDATA		8
+	#define CTX_PKTMODE		9
+	#define CTX_MOVEMASK		10
+	#define CTX_BTNDNMASK	11
+	#define CTX_BTNUPMASK	12
+	#define CTX_INORGX		13
+	#define CTX_INORGY		14
+	#define CTX_INORGZ		15
+	#define CTX_INEXTX		16
+	#define CTX_INEXTY		17
+	#define CTX_INEXTZ		18
+	#define CTX_OUTORGX		19
+	#define CTX_OUTORGY		20
+	#define CTX_OUTORGZ		21
+	#define CTX_OUTEXTX		22
+	#define CTX_OUTEXTY		23
+	#define CTX_OUTEXTZ		24
+	#define CTX_SENSX			25
+	#define CTX_SENSY			26
+	#define CTX_SENSZ			27
+	#define CTX_SYSMODE		28
+	#define CTX_SYSORGX		29
+	#define CTX_SYSORGY		30
+	#define CTX_SYSEXTX		31
+	#define CTX_SYSEXTY		32
+	#define CTX_SYSSENSX		33
+	#define CTX_SYSSENSY		34
+	#define CTX_MAX			34
+
+#endif
+
+#ifndef NOWTDEVICES
+
+#define WTI_DEVICES		100
+	#define DVC_NAME			1
+	#define DVC_HARDWARE		2
+	#define DVC_NCSRTYPES	3
+	#define DVC_FIRSTCSR		4
+	#define DVC_PKTRATE		5
+	#define DVC_PKTDATA		6
+	#define DVC_PKTMODE		7
+	#define DVC_CSRDATA		8
+	#define DVC_XMARGIN		9
+	#define DVC_YMARGIN		10
+	#define DVC_ZMARGIN		11
+	#define DVC_X				12
+	#define DVC_Y				13
+	#define DVC_Z				14
+	#define DVC_NPRESSURE	15
+	#define DVC_TPRESSURE	16
+	#define DVC_ORIENTATION	17
+	#define DVC_ROTATION		18 /* 1.1 */
+	#define DVC_PNPID			19 /* 1.1 */
+	#define DVC_MAX			19
+
+#endif
+
+#ifndef NOWTCURSORS
+
+#define WTI_CURSORS			200
+	#define CSR_NAME				1
+	#define CSR_ACTIVE			2
+	#define CSR_PKTDATA			3
+	#define CSR_BUTTONS			4
+	#define CSR_BUTTONBITS		5
+	#define CSR_BTNNAMES			6
+	#define CSR_BUTTONMAP		7
+	#define CSR_SYSBTNMAP		8
+	#define CSR_NPBUTTON			9
+	#define CSR_NPBTNMARKS		10
+	#define CSR_NPRESPONSE		11
+	#define CSR_TPBUTTON			12
+	#define CSR_TPBTNMARKS		13
+	#define CSR_TPRESPONSE		14
+	#define CSR_PHYSID			15 /* 1.1 */
+	#define CSR_MODE				16 /* 1.1 */
+	#define CSR_MINPKTDATA		17 /* 1.1 */
+	#define CSR_MINBUTTONS		18 /* 1.1 */
+	#define CSR_CAPABILITIES	19 /* 1.1 */
+	#define CSR_TYPE				20 /* 1.2 */
+	#define CSR_MAX				20
+
+#endif
+
+#ifndef NOWTEXTENSIONS
+
+#define WTI_EXTENSIONS	300
+	#define EXT_NAME			1
+	#define EXT_TAG			2
+	#define EXT_MASK			3
+	#define EXT_SIZE			4
+	#define EXT_AXES			5
+	#define EXT_DEFAULT		6
+	#define EXT_DEFCONTEXT	7
+	#define EXT_DEFSYSCTX	8
+	#define EXT_CURSORS		9
+	#define EXT_DEVICES     110 /* Allow 100 cursors */
+	#define EXT_MAX			210 /* Allow 100 devices */
+
+#endif
+
+#endif
+
+/* -------------------------------------------------------------------------- */
+/* CONTEXT DATA DEFS */
+
+#define LCNAMELEN		40
+#define LC_NAMELEN	40
+#ifdef WIN32
+typedef struct tagLOGCONTEXTA {
+	char	lcName[LCNAMELEN];
+	UINT	lcOptions;
+	UINT	lcStatus;
+	UINT	lcLocks;
+	UINT	lcMsgBase;
+	UINT	lcDevice;
+	UINT	lcPktRate;
+	WTPKT	lcPktData;
+	WTPKT	lcPktMode;
+	WTPKT	lcMoveMask;
+	DWORD	lcBtnDnMask;
+	DWORD	lcBtnUpMask;
+	LONG	lcInOrgX;
+	LONG	lcInOrgY;
+	LONG	lcInOrgZ;
+	LONG	lcInExtX;
+	LONG	lcInExtY;
+	LONG	lcInExtZ;
+	LONG	lcOutOrgX;
+	LONG	lcOutOrgY;
+	LONG	lcOutOrgZ;
+	LONG	lcOutExtX;
+	LONG	lcOutExtY;
+	LONG	lcOutExtZ;
+	FIX32	lcSensX;
+	FIX32	lcSensY;
+	FIX32	lcSensZ;
+	BOOL	lcSysMode;
+	int	lcSysOrgX;
+	int	lcSysOrgY;
+	int	lcSysExtX;
+	int	lcSysExtY;
+	FIX32	lcSysSensX;
+	FIX32	lcSysSensY;
+} LOGCONTEXTA, *PLOGCONTEXTA, NEAR *NPLOGCONTEXTA, FAR *LPLOGCONTEXTA;
+typedef struct tagLOGCONTEXTW {
+	WCHAR	lcName[LCNAMELEN];
+	UINT	lcOptions;
+	UINT	lcStatus;
+	UINT	lcLocks;
+	UINT	lcMsgBase;
+	UINT	lcDevice;
+	UINT	lcPktRate;
+	WTPKT	lcPktData;
+	WTPKT	lcPktMode;
+	WTPKT	lcMoveMask;
+	DWORD	lcBtnDnMask;
+	DWORD	lcBtnUpMask;
+	LONG	lcInOrgX;
+	LONG	lcInOrgY;
+	LONG	lcInOrgZ;
+	LONG	lcInExtX;
+	LONG	lcInExtY;
+	LONG	lcInExtZ;
+	LONG	lcOutOrgX;
+	LONG	lcOutOrgY;
+	LONG	lcOutOrgZ;
+	LONG	lcOutExtX;
+	LONG	lcOutExtY;
+	LONG	lcOutExtZ;
+	FIX32	lcSensX;
+	FIX32	lcSensY;
+	FIX32	lcSensZ;
+	BOOL	lcSysMode;
+	int	lcSysOrgX;
+	int	lcSysOrgY;
+	int	lcSysExtX;
+	int	lcSysExtY;
+	FIX32	lcSysSensX;
+	FIX32	lcSysSensY;
+} LOGCONTEXTW, *PLOGCONTEXTW, NEAR *NPLOGCONTEXTW, FAR *LPLOGCONTEXTW;
+#ifdef UNICODE
+typedef LOGCONTEXTW LOGCONTEXT;
+typedef PLOGCONTEXTW PLOGCONTEXT;
+typedef NPLOGCONTEXTW NPLOGCONTEXT;
+typedef LPLOGCONTEXTW LPLOGCONTEXT;
+#else
+typedef LOGCONTEXTA LOGCONTEXT;
+typedef PLOGCONTEXTA PLOGCONTEXT;
+typedef NPLOGCONTEXTA NPLOGCONTEXT;
+typedef LPLOGCONTEXTA LPLOGCONTEXT;
+#endif /* UNICODE */
+#else /* WIN32 */
+typedef struct tagLOGCONTEXT {
+	char	lcName[LCNAMELEN];
+	UINT	lcOptions;
+	UINT	lcStatus;
+	UINT	lcLocks;
+	UINT	lcMsgBase;
+	UINT	lcDevice;
+	UINT	lcPktRate;
+	WTPKT	lcPktData;
+	WTPKT	lcPktMode;
+	WTPKT	lcMoveMask;
+	DWORD	lcBtnDnMask;
+	DWORD	lcBtnUpMask;
+	LONG	lcInOrgX;
+	LONG	lcInOrgY;
+	LONG	lcInOrgZ;
+	LONG	lcInExtX;
+	LONG	lcInExtY;
+	LONG	lcInExtZ;
+	LONG	lcOutOrgX;
+	LONG	lcOutOrgY;
+	LONG	lcOutOrgZ;
+	LONG	lcOutExtX;
+	LONG	lcOutExtY;
+	LONG	lcOutExtZ;
+	FIX32	lcSensX;
+	FIX32	lcSensY;
+	FIX32	lcSensZ;
+	BOOL	lcSysMode;
+	int	lcSysOrgX;
+	int	lcSysOrgY;
+	int	lcSysExtX;
+	int	lcSysExtY;
+	FIX32	lcSysSensX;
+	FIX32	lcSysSensY;
+} LOGCONTEXT, *PLOGCONTEXT, NEAR *NPLOGCONTEXT, FAR *LPLOGCONTEXT;
+#endif /* WIN32 */
+
+	/* context option values */
+	#define CXO_SYSTEM		0x0001
+	#define CXO_PEN			0x0002
+	#define CXO_MESSAGES		0x0004
+	#define CXO_MARGIN		0x8000
+	#define CXO_MGNINSIDE	0x4000
+	#define CXO_CSRMESSAGES	0x0008 /* 1.1 */
+
+	/* context status values */
+	#define CXS_DISABLED		0x0001
+	#define CXS_OBSCURED		0x0002
+	#define CXS_ONTOP			0x0004
+
+	/* context lock values */
+	#define CXL_INSIZE		0x0001
+	#define CXL_INASPECT		0x0002
+	#define CXL_SENSITIVITY	0x0004
+	#define CXL_MARGIN		0x0008
+	#define CXL_SYSOUT		0x0010
+
+/* -------------------------------------------------------------------------- */
+/* EVENT DATA DEFS */
+
+/* For packet structure definition, see pktdef.h */
+
+/* packet status values */
+#define TPS_PROXIMITY		0x0001
+#define TPS_QUEUE_ERR		0x0002
+#define TPS_MARGIN			0x0004
+#define TPS_GRAB				0x0008
+#define TPS_INVERT			0x0010 /* 1.1 */
+
+typedef struct tagORIENTATION {
+	int orAzimuth;
+	int orAltitude;
+	int orTwist;
+} ORIENTATION, *PORIENTATION, NEAR *NPORIENTATION, FAR *LPORIENTATION;
+
+typedef struct tagROTATION { /* 1.1 */
+	int roPitch;
+	int roRoll;
+	int roYaw;
+} ROTATION, *PROTATION, NEAR *NPROTATION, FAR *LPROTATION;
+// grandfather in obsolete member names.
+#define rotPitch	roPitch
+#define rotRoll	roRoll
+#define rotYaw		roYaw
+
+
+/* relative buttons */
+#define TBN_NONE	0
+#define TBN_UP		1
+#define TBN_DOWN	2
+
+/* -------------------------------------------------------------------------- */
+/* DEVICE CONFIG CONSTANTS */
+
+#ifndef NOWTDEVCFG
+
+#define WTDC_NONE		0
+#define WTDC_CANCEL		1
+#define WTDC_OK			2
+#define WTDC_RESTART	3
+
+#endif
+
+/* -------------------------------------------------------------------------- */
+/* HOOK CONSTANTS */
+
+#ifndef NOWTHOOKS
+
+#define WTH_PLAYBACK			1
+#define WTH_RECORD			2
+
+#define WTHC_GETLPLPFN		(-3)
+#define WTHC_LPLPFNNEXT		(-2)
+#define WTHC_LPFNNEXT		(-1)
+#define WTHC_ACTION			0
+#define WTHC_GETNEXT			1
+#define WTHC_SKIP				2
+
+#endif
+
+/* -------------------------------------------------------------------------- */
+/* PREFERENCE FUNCTION CONSTANTS */
+
+#ifndef NOWTPREF
+
+#define WTP_LPDEFAULT	((LPVOID)-1L)
+#define WTP_DWDEFAULT	((DWORD)-1L)
+
+#endif
+
+/* -------------------------------------------------------------------------- */
+/* EXTENSION TAGS AND CONSTANTS */
+
+#ifndef NOWTEXTENSIONS
+
+/* constants for use with pktdef.h */
+#define PKEXT_ABSOLUTE	1
+#define PKEXT_RELATIVE	2
+
+/* Extension tags. */
+#define WTX_OBT				0	/* Out of bounds tracking */
+#define WTX_FKEYS				1	/* Function keys */
+#define WTX_TILT				2	/* Raw Cartesian tilt; 1.1 */
+#define WTX_CSRMASK			3	/* select input by cursor type; 1.1 */
+#define WTX_XBTNMASK			4	/* Extended button mask; 1.1 */
+#define WTX_EXPKEYS			5	/* ExpressKeys; 1.3 - DEPRECATED: see WTX_EXPKEYS2 */
+#define WTX_TOUCHSTRIP		6	/* TouchStrips; 1.4 */
+#define WTX_TOUCHRING		7	/* TouchRings; 1.4 */
+#define WTX_EXPKEYS2			8	/* ExpressKeys; 1.4 */
+
+typedef struct tagXBTNMASK {
+	BYTE xBtnDnMask[32];
+	BYTE xBtnUpMask[32];
+} XBTNMASK;
+
+typedef struct tagTILT { /* 1.1 */
+	int tiltX;
+	int tiltY;
+} TILT;
+
+typedef struct tagEXTENSIONBASE { /* 1.4 */
+	HCTX		nContext;
+	UINT		nStatus;
+	DWORD		nTime;
+	UINT		nSerialNumber;
+} EXTENSIONBASE;
+
+typedef struct tagEXPKEYSDATA { /* 1.4 */
+	BYTE		nTablet;
+	BYTE		nControl;
+	BYTE		nLocation;
+	BYTE		nReserved;
+	DWORD		nState;
+} EXPKEYSDATA;
+
+typedef struct tagSLIDERDATA { /* 1.4 */
+	BYTE		nTablet;
+	BYTE		nControl;
+	BYTE		nMode;
+	BYTE		nReserved;
+	DWORD		nPosition;
+} SLIDERDATA;
+
+typedef struct tagEXTPROPERTY { /* 1.4 */
+	BYTE		version;				// Structure version, 0 for now
+	BYTE		tabletIndex;		// 0-based index for tablet
+	BYTE		controlIndex;		// 0-based index for control 
+	BYTE		functionIndex;		// 0-based index for control's sub-function
+	WORD		propertyID;			// property ID
+	WORD		reserved;			// DWORD-alignment filler
+	DWORD		dataSize;			// number of bytes in data[] buffer
+	BYTE		data[1];				// raw data
+} EXTPROPERTY;
+
+#define TABLET_PROPERTY_CONTROLCOUNT	 0			// UINT32: number of physical controls on tablet
+#define TABLET_PROPERTY_FUNCCOUNT		 1			// UINT32: number of functions of control
+#define TABLET_PROPERTY_AVAILABLE		 2			// BOOL: control/mode is available for override
+#define TABLET_PROPERTY_MIN				 3			// UINT32: minimum value
+#define TABLET_PROPERTY_MAX				 4			// UINT32: maximum value
+#define TABLET_PROPERTY_OVERRIDE			 5			// BOOL: control is overridden
+#define TABLET_PROPERTY_OVERRIDE_NAME	 6			// UTF-8: Displayable name when control is overridden
+#define TABLET_PROPERTY_LOCATION			 11		// UINT32: Physical location of control (see TABLET_LOC_*)
+
+#define TABLET_LOC_LEFT				0
+#define TABLET_LOC_RIGHT			1
+#define TABLET_LOC_TOP				2
+#define TABLET_LOC_BOTTOM			3
+#define TABLET_LOC_TRANSDUCER		4
+
+#endif
+
+/* -------------------------------------------------------------------------- */
+/* -------------------------------------------------------------------------- */
+/* Functions */
+
+	#ifndef API
+		#ifndef WINAPI
+			#define API			FAR PASCAL
+		#else
+			#define API			WINAPI
+		#endif
+	#endif
+
+#ifndef NOWTCALLBACKS
+
+	#ifndef CALLBACK
+	#define CALLBACK	FAR PASCAL
+	#endif
+
+	#ifndef NOWTMANAGERFXNS
+	/* callback function types */
+	typedef BOOL (WINAPI * WTENUMPROC)(HCTX, LPARAM); /* changed CALLBACK->WINAPI, 1.1 */
+	typedef BOOL (WINAPI * WTCONFIGPROC)(HCTX, HWND);
+	typedef LRESULT (WINAPI * WTHOOKPROC)(int, WPARAM, LPARAM);
+	typedef WTHOOKPROC FAR *LPWTHOOKPROC;
+	#endif
+
+#endif
+
+
+#ifndef NOWTFUNCTIONS
+
+	#ifndef NOWTBASICFXNS
+	/* BASIC FUNCTIONS */
+#ifdef WIN32
+	UINT API WTInfoA(UINT, UINT, LPVOID);
+	#define ORD_WTInfoA						20
+	UINT API WTInfoW(UINT, UINT, LPVOID);
+	#define ORD_WTInfoW						1020
+	#ifdef UNICODE
+	#define WTInfo			WTInfoW
+	#define ORD_WTInfo	ORD_WTInfoW
+	#else
+	#define WTInfo			WTInfoA
+	#define ORD_WTInfo	ORD_WTInfoA
+	#endif /* !UNICODE */
+#else
+	UINT API WTInfo(UINT, UINT, LPVOID);
+	#define ORD_WTInfo							20
+#endif
+#ifdef WIN32
+	HCTX API WTOpenA(HWND, LPLOGCONTEXTA, BOOL);
+	#define ORD_WTOpenA							21
+	HCTX API WTOpenW(HWND, LPLOGCONTEXTW, BOOL);
+	#define ORD_WTOpenW							1021
+	#ifdef UNICODE
+	#define WTOpen			WTOpenW
+	#define ORD_WTOpen	ORD_WTOpenW
+	#else
+	#define WTOpen			WTOpenA
+	#define ORD_WTOpen	ORD_WTOpenA
+	#endif /* !UNICODE */
+#else
+	HCTX API WTOpen(HWND, LPLOGCONTEXT, BOOL);
+	#define ORD_WTOpen							21
+#endif
+	BOOL API WTClose(HCTX);
+	#define ORD_WTClose							22
+	int API WTPacketsGet(HCTX, int, LPVOID);
+	#define ORD_WTPacketsGet					23
+	BOOL API WTPacket(HCTX, UINT, LPVOID);
+	#define ORD_WTPacket							24
+	#endif
+
+	#ifndef NOWTVISIBILITYFXNS
+	/* VISIBILITY FUNCTIONS */
+	BOOL API WTEnable(HCTX, BOOL);
+	#define ORD_WTEnable							40
+	BOOL API WTOverlap(HCTX, BOOL);
+	#define ORD_WTOverlap						41
+	#endif
+
+	#ifndef NOWTCTXEDITFXNS
+	/* CONTEXT EDITING FUNCTIONS */
+	BOOL API WTConfig(HCTX, HWND);
+	#define ORD_WTConfig							60
+#ifdef WIN32
+	BOOL API WTGetA(HCTX, LPLOGCONTEXTA);
+	#define ORD_WTGetA							61
+	BOOL API WTGetW(HCTX, LPLOGCONTEXTW);
+	#define ORD_WTGetW							1061
+	#ifdef UNICODE
+	#define WTGet			WTGetW
+	#define ORD_WTGet		ORD_WTGetW
+	#else
+	#define WTGet			WTGetA
+	#define ORD_WTGet		ORD_WTGetA
+	#endif /* !UNICODE */
+#else
+	BOOL API WTGet(HCTX, LPLOGCONTEXT);
+	#define ORD_WTGet								61
+#endif
+#ifdef WIN32
+	BOOL API WTSetA(HCTX, LPLOGCONTEXTA);
+	#define ORD_WTSetA							62
+	BOOL API WTSetW(HCTX, LPLOGCONTEXTW);
+	#define ORD_WTSetW							1062
+	#ifdef UNICODE
+	#define WTSet			WTSetW
+	#define ORD_WTSet		ORD_WTSetW
+	#else
+	#define WTSet			WTSetA
+	#define ORD_WTSet		ORD_WTSetA
+	#endif /* !UNICODE */
+#else
+	BOOL API WTSet(HCTX, LPLOGCONTEXT);
+	#define ORD_WTSet								62
+#endif
+	BOOL API WTExtGet(HCTX, UINT, LPVOID);
+	#define ORD_WTExtGet							63
+	BOOL API WTExtSet(HCTX, UINT, LPVOID);
+	#define ORD_WTExtSet							64
+	BOOL API WTSave(HCTX, LPVOID);
+	#define ORD_WTSave							65
+	HCTX API WTRestore(HWND, LPVOID, BOOL);
+	#define ORD_WTRestore						66
+	#endif
+
+	#ifndef NOWTQUEUEFXNS
+	/* ADVANCED PACKET AND QUEUE FUNCTIONS */
+	int API WTPacketsPeek(HCTX, int, LPVOID);
+	#define ORD_WTPacketsPeek					80
+	int API WTDataGet(HCTX, UINT, UINT, int, LPVOID, LPINT);
+	#define ORD_WTDataGet						81
+	int API WTDataPeek(HCTX, UINT, UINT, int, LPVOID, LPINT);
+	#define ORD_WTDataPeek						82
+#ifndef WIN32
+/* OBSOLETE IN WIN32! */
+	DWORD API WTQueuePackets(HCTX);
+	#define ORD_WTQueuePackets					83
+#endif
+	int API WTQueueSizeGet(HCTX);
+	#define ORD_WTQueueSizeGet					84
+	BOOL API WTQueueSizeSet(HCTX, int);
+	#define ORD_WTQueueSizeSet					85
+	#endif
+
+	#ifndef NOWTHMGRFXNS
+	/* MANAGER HANDLE FUNCTIONS */
+	HMGR API WTMgrOpen(HWND, UINT);
+	#define ORD_WTMgrOpen						100
+	BOOL API WTMgrClose(HMGR);
+	#define ORD_WTMgrClose						101
+	#endif
+
+	#ifndef NOWTMGRCTXFXNS
+	/* MANAGER CONTEXT FUNCTIONS */
+	BOOL API WTMgrContextEnum(HMGR, WTENUMPROC, LPARAM);
+	#define ORD_WTMgrContextEnum				120
+	HWND API WTMgrContextOwner(HMGR, HCTX);
+	#define ORD_WTMgrContextOwner				121
+	HCTX API WTMgrDefContext(HMGR, BOOL);
+	#define ORD_WTMgrDefContext				122
+	HCTX API WTMgrDefContextEx(HMGR, UINT, BOOL); /* 1.1 */
+	#define ORD_WTMgrDefContextEx				206
+	#endif
+	
+	#ifndef NOWTMGRCONFIGFXNS
+	/* MANAGER CONFIG BOX  FUNCTIONS */
+	UINT API WTMgrDeviceConfig(HMGR, UINT, HWND);
+	#define ORD_WTMgrDeviceConfig				140
+#ifndef WIN32
+/* OBSOLETE IN WIN32! */
+	BOOL API WTMgrConfigReplace(HMGR, BOOL, WTCONFIGPROC);
+	#define ORD_WTMgrConfigReplace			141
+#endif
+	#endif
+
+	#ifndef NOWTMGRHOOKFXNS
+	/* MANAGER PACKET HOOK FUNCTIONS */
+#ifndef WIN32
+/* OBSOLETE IN WIN32! */
+	WTHOOKPROC API WTMgrPacketHook(HMGR, BOOL, int, WTHOOKPROC);
+	#define ORD_WTMgrPacketHook				160
+	LRESULT API WTMgrPacketHookDefProc(int, WPARAM, LPARAM, LPWTHOOKPROC);
+	#define ORD_WTMgrPacketHookDefProc		161
+#endif
+	#endif
+
+	#ifndef NOWTMGRPREFFXNS
+	/* MANAGER PREFERENCE DATA FUNCTIONS */
+	BOOL API WTMgrExt(HMGR, UINT, LPVOID);
+	#define ORD_WTMgrExt							180
+	BOOL API WTMgrCsrEnable(HMGR, UINT, BOOL);
+	#define ORD_WTMgrCsrEnable					181
+	BOOL API WTMgrCsrButtonMap(HMGR, UINT, LPBYTE, LPBYTE);
+	#define ORD_WTMgrCsrButtonMap				182
+	BOOL API WTMgrCsrPressureBtnMarks(HMGR, UINT, DWORD, DWORD);
+	#define ORD_WTMgrCsrPressureBtnMarks	183
+	BOOL API WTMgrCsrPressureResponse(HMGR, UINT, UINT FAR *, UINT FAR *);
+	#define ORD_WTMgrCsrPressureResponse	184
+	BOOL API WTMgrCsrExt(HMGR, UINT, UINT, LPVOID);
+	#define ORD_WTMgrCsrExt						185
+	#endif
+
+/* Win32 replacements for non-portable functions. */
+	#ifndef NOWTQUEUEFXNS
+	/* ADVANCED PACKET AND QUEUE FUNCTIONS */
+	BOOL API WTQueuePacketsEx(HCTX, UINT FAR *, UINT FAR *);
+	#define ORD_WTQueuePacketsEx				200
+	#endif
+
+	#ifndef NOWTMGRCONFIGFXNS
+	/* MANAGER CONFIG BOX  FUNCTIONS */
+#ifdef WIN32
+	BOOL API WTMgrConfigReplaceExA(HMGR, BOOL, LPSTR, LPSTR);
+	#define ORD_WTMgrConfigReplaceExA		202
+	BOOL API WTMgrConfigReplaceExW(HMGR, BOOL, LPWSTR, LPSTR);
+	#define ORD_WTMgrConfigReplaceExW		1202
+	#ifdef UNICODE
+	#define WTMgrConfigReplaceEx			WTMgrConfigReplaceExW
+	#define ORD_WTMgrConfigReplaceEx		ORD_WTMgrConfigReplaceExW
+	#else
+	#define WTMgrConfigReplaceEx			WTMgrConfigReplaceExA
+	#define ORD_WTMgrConfigReplaceEx		ORD_WTMgrConfigReplaceExA
+	#endif /* !UNICODE */
+#else
+	BOOL API WTMgrConfigReplaceEx(HMGR, BOOL, LPSTR, LPSTR);
+	#define ORD_WTMgrConfigReplaceEx			202
+#endif
+	#endif
+
+	#ifndef NOWTMGRHOOKFXNS
+	/* MANAGER PACKET HOOK FUNCTIONS */
+#ifdef WIN32
+	HWTHOOK API WTMgrPacketHookExA(HMGR, int, LPSTR, LPSTR);
+	#define ORD_WTMgrPacketHookExA			203
+	HWTHOOK API WTMgrPacketHookExW(HMGR, int, LPWSTR, LPSTR);
+	#define ORD_WTMgrPacketHookExW			1203
+	#ifdef UNICODE
+	#define WTMgrPacketHookEx			WTMgrPacketHookExW
+	#define ORD_WTMgrPacketHookEx		ORD_WTMgrPacketHookExW
+	#else
+	#define WTMgrPacketHookEx			WTMgrPacketHookExA
+	#define ORD_WTMgrPacketHookEx		ORD_WTMgrPacketHookExA
+	#endif /* !UNICODE */
+#else
+	HWTHOOK API WTMgrPacketHookEx(HMGR, int, LPSTR, LPSTR);
+	#define ORD_WTMgrPacketHookEx				203
+#endif
+	BOOL API WTMgrPacketUnhook(HWTHOOK);
+	#define ORD_WTMgrPacketUnhook				204
+	LRESULT API WTMgrPacketHookNext(HWTHOOK, int, WPARAM, LPARAM);
+	#define ORD_WTMgrPacketHookNext			205
+	#endif
+
+	#ifndef NOWTMGRPREFFXNS
+	/* MANAGER PREFERENCE DATA FUNCTIONS */
+	BOOL API WTMgrCsrPressureBtnMarksEx(HMGR, UINT, UINT FAR *, UINT FAR *);
+	#define ORD_WTMgrCsrPressureBtnMarksEx	201
+	#endif
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif	/* __cplusplus */

--- a/makefile
+++ b/makefile
@@ -63,6 +63,7 @@ OBJS = \
 	src\windows\threadw.obj \
 	src\windows\time.obj \
 	src\windows\tlsw.obj \
+	src\windows\wintab.obj \
 	src\windows\gfx\d3d12.obj \
 	src\windows\gfx\d3d12-ctx.obj \
 	src\windows\gfx\d3d12-ui.obj \

--- a/src/app.c
+++ b/src/app.c
@@ -157,8 +157,10 @@ void MTY_PrintEvent(const MTY_Event *evt)
 		PEVENT(MTY_EVENT_CLIPBOARD, evt, "");
 		PEVENT(MTY_EVENT_TRAY, evt, "id: %u", evt->trayID);
 		PEVENT(MTY_EVENT_REOPEN, evt, "arg: %s", evt->reopenArg);
-		PEVENT(MTY_EVENT_PEN, evt, "x: %u, y: %u, flags: 0x%X, pressure: %u, rotation: %u, tiltX: %d, tiltY: %d",
-			evt->pen.x, evt->pen.y, evt->pen.flags, evt->pen.pressure, evt->pen.rotation, evt->pen.tiltX, evt->pen.tiltY);
+		PEVENT(MTY_EVENT_PEN, evt, "x: %u, y: %u, z: %u, flags: 0x%X, pressure: %u, rotation: %u, tiltX: %d, tiltY: %d",
+			evt->pen.x, evt->pen.y, evt->pen.z, evt->pen.flags, evt->pen.pressure, evt->pen.rotation, evt->pen.tiltX, evt->pen.tiltY);
+		PEVENT(MTY_EVENT_WINTAB, evt, "type: %d, device: %d, control: %d, state: %d, position: %d",
+			evt->wintab.type, evt->wintab.device, evt->wintab.control, evt->wintab.state, evt->wintab.position);
 		PEVENT(MTY_EVENT_CONNECT, evt, "id: %u", evt->controller.id);
 		PEVENT(MTY_EVENT_DISCONNECT, evt, "id: %u", evt->controller.id);
 		PEVENT(MTY_EVENT_SIZE, evt, "");

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -337,6 +337,7 @@ typedef enum {
 	MTY_EVENT_BACK         = 19, ///< The mobile back command has been triggered.
 	MTY_EVENT_SIZE         = 20, ///< The size of a window has changed.
 	MTY_EVENT_MOVE         = 21, ///< The window's top left corner has moved.
+	MTY_EVENT_WINTAB       = 22, ///< Creative tablets extended input has occurred.
 	MTY_EVENT_MAKE_32      = INT32_MAX,
 } MTY_EventType;
 
@@ -617,6 +618,13 @@ typedef enum {
 	MTY_CONTEXT_STATE_MAKE_32 = INT32_MAX,
 } MTY_ContextState;
 
+/// @brief Wintab input type.
+typedef enum {
+	MTY_WINTAB_TYPE_KEY,   ///< The Wintab input comes from an ExpressKey button.
+	MTY_WINTAB_TYPE_STRIP, ///< The Wintab input comes from a TouchStrip manipulation.
+	MTY_WINTAB_TYPE_RING   ///< The Wintab input comes from a TouchRing manipulation.
+} MTY_WintabType;
+
 /// @brief Key event.
 typedef struct {
 	MTY_Key key;  ///< The key that has been pressed or released.
@@ -681,11 +689,21 @@ typedef struct {
 	MTY_PenFlag flags; ///< Pen attributes.
 	uint16_t x;        ///< The horizontal position in the client area of the window.
 	uint16_t y;        ///< The vertical position in the client area of the window.
+	uint16_t z;        ///< The elevation position in the client area of the window.
 	uint16_t pressure; ///< Pressure on the drawing surface between 0 and 1024.
 	uint16_t rotation; ///< Rotation of the pen between 0 and 359.
 	int8_t tiltX;      ///< Horizontal tilt of the pen between -90 and 90.
 	int8_t tiltY;      ///< Vertical tilt of the pen between -90 and 90.
 } MTY_PenEvent;
+
+/// @brief Wintab input event.
+typedef struct {
+	MTY_WintabType type; ///< The Wintab input type.
+	uint16_t position;   ///< The position of the control (when applicable).
+	uint8_t device;      ///< The originating Wintab device.
+	uint8_t control;     ///< The control identifier on the device.
+	uint8_t state;       ///< The state of the control.
+} MTY_WintabEvent;
 
 /// @brief App event encapsulating all event types.
 /// @details First inspect the `type` member to determine what kind of event it is,
@@ -703,6 +721,7 @@ typedef struct MTY_Event {
 		MTY_DropEvent drop;             ///< Valid on MTY_EVENT_DROP.
 		MTY_PenEvent pen;               ///< Valid on MTY_EVENT_PEN.
 		MTY_KeyEvent key;               ///< Valid on MTY_EVENT_KEY.
+		MTY_WintabEvent wintab;         ///< Valid on MTY_EVENT_WINTAB.
 
 		const char *reopenArg; ///< Valid on MTY_EVENT_REOPEN, the argument supplied.
 		uint32_t hotkey;       ///< Valid on MTY_EVENT_HOTKEY, the `id` set via MTY_AppSetHotkey.
@@ -1012,6 +1031,16 @@ MTY_AppIsPenEnabled(MTY_App *ctx);
 //- #support Windows macOS
 MTY_EXPORT void
 MTY_AppEnablePen(MTY_App *ctx, bool enable);
+
+/// @brief Enable or disable extended tablet controls override.
+/// @details When overriden, tablet controls (e.g. ExpressKeys) will be received as
+///   through the MTY_EVENT_WINTAB event, and their configured keystrokes will not
+///   be executed. 
+/// @param ctx The MTY_App.
+/// @param enable Set true to override controls, false to revert the override.
+//- #support Windows
+MTY_EXPORT void
+MTY_AppOverrideTabletControls(MTY_App *ctx, bool override);
 
 /// @brief Get the app's current mobile input mode.
 /// @param ctx The MTY_App.

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -620,9 +620,10 @@ typedef enum {
 
 /// @brief Wintab input type.
 typedef enum {
-	MTY_WINTAB_TYPE_KEY,   ///< The Wintab input comes from an ExpressKey button.
-	MTY_WINTAB_TYPE_STRIP, ///< The Wintab input comes from a TouchStrip manipulation.
-	MTY_WINTAB_TYPE_RING   ///< The Wintab input comes from a TouchRing manipulation.
+	MTY_WINTAB_TYPE_KEY     = 0, ///< The Wintab input comes from an ExpressKey button.
+	MTY_WINTAB_TYPE_STRIP   = 1, ///< The Wintab input comes from a TouchStrip manipulation.
+	MTY_WINTAB_TYPE_RING    = 2, ///< The Wintab input comes from a TouchRing manipulation.
+	MTY_WINTAB_TYPE_MAKE_32 = INT32_MAX,
 } MTY_WintabType;
 
 /// @brief Key event.

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -7,6 +7,7 @@
 #include "app.h"
 
 #include <stdio.h>
+#define _USE_MATH_DEFINES
 #include <math.h>
 
 #include <windows.h>
@@ -15,6 +16,17 @@
 #include <shobjidl.h>
 #include <shellscalingapi.h>
 #include <dbt.h>
+
+#include "wintab/MSGPACK.H"
+#define NOWTFUNCTIONS
+#include "wintab/WINTAB.H"
+#define PACKETDATA       (PK_CONTEXT | PK_STATUS | PK_TIME | PK_CHANGED | PK_SERIAL_NUMBER | PK_CURSOR | PK_BUTTONS |\
+                          PK_X | PK_Y | PK_Z | PK_NORMAL_PRESSURE | PK_TANGENT_PRESSURE | PK_ORIENTATION | PK_ROTATION)
+#define PACKETMODE       0
+#define PACKETEXPKEYS    PKEXT_ABSOLUTE
+#define PACKETTOUCHSTRIP PKEXT_ABSOLUTE
+#define PACKETTOUCHRING  PKEXT_ABSOLUTE
+#include "wintab/PKTDEF.H"
 
 #include "xip.h"
 #include "wsize.h"
@@ -54,6 +66,7 @@ struct MTY_App {
 	DWORD cb_seq;
 	bool pen_in_range;
 	bool pen_enabled;
+	bool pen_had_barrel;
 	bool touch_active;
 	bool relative;
 	bool kbgrab;
@@ -69,6 +82,7 @@ struct MTY_App {
 	int32_t last_y;
 	struct hid *hid;
 	struct xip *xip;
+	struct wintab *wintab;
 	MTY_Button buttons;
 	MTY_DetachState detach;
 	MTY_Hash *hotkey;
@@ -99,6 +113,33 @@ struct MTY_App {
 	BOOL (WINAPI *GetPointerPenInfo)(UINT32 pointerId, POINTER_PEN_INFO *penInfo);
 };
 
+typedef UINT(API *WTINFOA)(UINT, UINT, LPVOID);
+typedef HCTX(API *WTOPENA)(HWND, LPLOGCONTEXTA, BOOL);
+typedef BOOL(API *WTCLOSE)(HCTX);
+typedef BOOL(API *WTPACKET)(HCTX, UINT, LPVOID);
+typedef BOOL(API *WTEXTGET)(HCTX, UINT, LPVOID);
+typedef BOOL(API *WTEXTSET)(HCTX, UINT, LPVOID);
+
+struct wintab
+{
+	MTY_SO *instance;
+	HCTX context;
+	MTY_PenEvent prev_evt;
+	PACKETEXT prev_pktext;
+	DWORD prev_buttons;
+
+	bool override;
+	int32_t min_altitude;
+	int32_t max_altitude;
+	int32_t max_pressure;
+
+	WTINFOA  InfoA;
+	WTOPENA  OpenA;
+	WTCLOSE  Close;
+	WTPACKET Packet;
+	WTEXTGET ExtGet;
+	WTEXTSET ExtSet;
+};
 
 // MTY -> VK mouse map
 
@@ -620,6 +661,207 @@ static void app_kb_to_hotkey(MTY_App *app, MTY_Event *evt)
 	}
 }
 
+static bool app_wintab_find_extension(struct wintab *wintab, uint32_t searched_tag, uint32_t *index)
+{
+	uint32_t current;
+
+	for (uint32_t i = 0; wintab->InfoA(WTI_EXTENSIONS + i, EXT_TAG, &current); i++)
+	{
+		if (current != searched_tag)
+			continue;
+
+		*index = i;
+		return true;
+	}
+
+	return false;
+}
+
+static void app_wintab_override_extension(struct wintab *wintab, uint8_t tablet_i, uint32_t extension)
+{
+	// Retrieve the number of controls for the given extension
+	EXTPROPERTY props = {0};
+	props.propertyID = TABLET_PROPERTY_CONTROLCOUNT;
+	props.tabletIndex = tablet_i;
+
+	if (!wintab->ExtGet(wintab->context, extension, &props))
+		return;
+	uint8_t controls = props.data[0];
+
+	for (uint8_t control_i = 0; control_i < controls; control_i++) {
+		// Retrieve the number of functions for the current control
+		props.propertyID = TABLET_PROPERTY_FUNCCOUNT;
+		props.controlIndex = control_i;
+
+		if (!wintab->ExtGet(wintab->context, extension, &props))
+			return;
+		uint8_t functions = props.data[0];
+
+		for (uint8_t function_i = 0; function_i < functions; function_i++) {
+			// Mark the current function as overriden by the application
+			props.propertyID = TABLET_PROPERTY_OVERRIDE;
+			props.functionIndex = function_i;
+			props.dataSize = sizeof(bool);
+			props.data[0] = wintab->override;
+
+			wintab->ExtSet(wintab->context, extension, &props);
+		}
+	}
+}
+
+static void app_wintab_destroy(MTY_App *ctx, bool unload)
+{
+	if (!ctx->wintab)
+		return;
+
+	if (ctx->wintab->context) {
+		ctx->wintab->Close(ctx->wintab->context);
+		ctx->wintab->context = NULL;
+	}
+
+	if (!unload)
+		return;
+
+	if (ctx->wintab->instance)
+		MTY_SOUnload(&ctx->wintab->instance);
+
+	MTY_Free(ctx->wintab);
+	ctx->wintab = NULL;
+}
+
+static bool app_wintab_create(MTY_App *ctx)
+{
+	if (ctx->wintab && ctx->wintab->context)
+		return true;
+
+	bool r = false;
+
+	// Symbols are preserved between runtime destructions, so we only initialize them once 
+	if (!ctx->wintab) {
+		ctx->wintab = MTY_Alloc(1, sizeof(struct wintab));
+		if (!ctx->wintab)
+			goto except;
+
+		ctx->wintab->instance = MTY_SOLoad("Wintab32.dll");
+		if (!ctx->wintab->instance)
+			goto except;
+
+		#define MAP(type, func) ctx->wintab->##func = (type)MTY_SOGetSymbol(ctx->wintab->instance, "WT" #func); \
+		                        if (!ctx->wintab->##func) goto except;
+
+		MAP(WTINFOA,  InfoA);
+		MAP(WTOPENA,  OpenA);
+		MAP(WTCLOSE,  Close);
+		MAP(WTPACKET, Packet);
+		MAP(WTEXTGET, ExtGet);
+		MAP(WTEXTSET, ExtSet);
+
+		if (!ctx->wintab->InfoA(0, 0, NULL))
+			goto except;
+	}
+
+	// Retrieve a default system context from Wintab
+	LOGCONTEXTA lc = {0};
+	ctx->wintab->InfoA(WTI_DEFSYSCTX, 0, &lc);
+
+	uint32_t touch_strip_i = 0,    touch_ring_i = 0,    exp_keys_i = 0;
+	uint32_t touch_strip_mask = 0, touch_ring_mask = 0, exp_keys_mask = 0;
+
+	if (app_wintab_find_extension(ctx->wintab, WTX_TOUCHSTRIP, &touch_strip_i))
+		ctx->wintab->InfoA(WTI_EXTENSIONS + touch_strip_i, EXT_MASK, &touch_strip_mask);
+
+	if (app_wintab_find_extension(ctx->wintab, WTX_TOUCHRING, &touch_ring_i))
+		ctx->wintab->InfoA(WTI_EXTENSIONS + touch_ring_i, EXT_MASK, &touch_ring_mask);
+
+	if (app_wintab_find_extension(ctx->wintab, WTX_EXPKEYS2, &exp_keys_i))
+		ctx->wintab->InfoA(WTI_EXTENSIONS + exp_keys_i, EXT_MASK, &exp_keys_mask);
+
+	lc.lcOptions = CXO_MESSAGES | CXO_SYSTEM;
+	lc.lcPktData = PACKETDATA | touch_strip_mask | touch_ring_mask | exp_keys_mask;
+	lc.lcOutExtY = -lc.lcOutExtY;
+
+	ctx->wintab->context = ctx->wintab->OpenA(app_get_main_hwnd(ctx), &lc, TRUE);
+	if (!ctx->wintab->context)
+		goto except;
+
+	// Wintab only supports up to 16 devices working at the same time
+	for (uint8_t i = 0; i < 16; i++) {
+		if (!ctx->wintab->InfoA(WTI_DDCTXS + i, 0, NULL))
+			break;
+
+		app_wintab_override_extension(ctx->wintab, i, WTX_TOUCHSTRIP);
+		app_wintab_override_extension(ctx->wintab, i, WTX_TOUCHRING);
+		app_wintab_override_extension(ctx->wintab, i, WTX_EXPKEYS2);
+	}
+
+	AXIS ncaps = {0};
+	ctx->wintab->InfoA(WTI_DEVICES, DVC_NPRESSURE, &ncaps);
+	ctx->wintab->max_pressure = ncaps.axMax;
+
+	AXIS ocaps[3] = {0};
+	ctx->wintab->InfoA(WTI_DEVICES, DVC_ORIENTATION, &ocaps);
+	ctx->wintab->min_altitude = ocaps[1].axMin;
+	ctx->wintab->max_altitude = ocaps[1].axMax;
+
+	r = true;
+
+	except:
+
+	if (!r)
+		app_wintab_destroy(ctx, true);
+
+	return r;
+}
+
+static bool app_wintab_adjust_position(HWND hwnd, int32_t pointer_x, int32_t pointer_y, POINT *position) 
+{
+	POINT origin = {0};
+	if (!ClientToScreen(hwnd, &origin))
+		return false;
+
+	RECT size = {0};
+	if (!GetClientRect(hwnd, &size))
+		return false;
+
+	POINT point = {pointer_x, pointer_y};
+	if (!PhysicalToLogicalPointForPerMonitorDPI(hwnd, &point))
+		return false;
+
+	int32_t x      = (int32_t) (point.x - origin.x);
+	int32_t y      = (int32_t) (point.y - origin.y);
+	int32_t width  = size.right  - size.left;
+	int32_t height = size.bottom - size.top;
+
+	if (x < 0 || x > width || y < 0 || y > height)
+		return false;
+
+	position->x = x;
+	position->y = y;
+
+	return true;
+}
+
+static HWND app_wintab_get_hovered_window(MTY_App *ctx, int32_t pointer_x, int32_t pointer_y, POINT *position)
+{
+	HWND hwnd = GetActiveWindow();
+	if (!hwnd)
+		return NULL;
+
+	if (app_wintab_adjust_position(hwnd, pointer_x, pointer_y, position))
+		return hwnd;
+
+	for (uint8_t i = 0; i < MTY_WINDOW_MAX; i++) {
+		if (!ctx->windows[i])
+			continue;
+
+		hwnd = ctx->windows[i]->hwnd;
+		if (app_wintab_adjust_position(hwnd, pointer_x, pointer_y, position))
+			return hwnd;
+	}
+
+	return NULL;
+}
+
 static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
 {
 	MTY_App *app = ctx->app;
@@ -758,7 +1000,8 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 			break;
 		}
 		case WM_POINTERLEAVE:
-			app->pen_in_range = false;
+			if (!app->wintab)
+				app->pen_in_range = false;
 			app->touch_active = false;
 			break;
 		case WM_POINTERUPDATE:
@@ -807,8 +1050,11 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 			if (ppi.penFlags & PEN_FLAG_ERASER)
 				evt.pen.flags |= MTY_PEN_FLAG_ERASER;
 
-			if (ppi.penFlags & PEN_FLAG_BARREL)
+			// We must send a last barrel to notify it has been released
+			bool pen_barrel = (ppi.penFlags & PEN_FLAG_BARREL) ? true : false;
+			if (pen_barrel || app->pen_had_barrel)
 				evt.pen.flags |= MTY_PEN_FLAG_BARREL;
+			app->pen_had_barrel = pen_barrel;
 
 			defreturn = true;
 			break;
@@ -875,6 +1121,127 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 			// https://social.msdn.microsoft.com/Forums/vstudio/en-US/ab973de0-da5f-4e26-8f7c-ac099396c830
 			if (wparam == DBT_DEVNODES_CHANGED && app->tray.menu_open)
 				EndMenu();
+			break;
+		case WT_PACKET: {
+			if (!app->wintab || !app->pen_in_range)
+				break;
+
+			PACKET pkt = {0};
+			app->wintab->Packet((HCTX) lparam, (UINT) wparam, &pkt);
+
+			POINT position = {0};
+			HWND focused_window = app_wintab_get_hovered_window(app, pkt.pkX, pkt.pkY, &position);
+			if (!focused_window)
+				break;
+
+			// Wintab context only catches events on the main window, so we update the real one manually
+			struct window *new_ctx = (struct window *) GetWindowLongPtr(focused_window, 0);
+			evt.window = new_ctx->window;
+
+			evt.type = MTY_EVENT_PEN;
+
+			evt.pen.x = (uint16_t) position.x;
+			evt.pen.y = (uint16_t) position.y;
+			evt.pen.z = (uint16_t) pkt.pkZ;
+
+			evt.pen.pressure = (uint16_t) (pkt.pkNormalPressure / (double)app->wintab->max_pressure * 1024.0);
+			evt.pen.rotation = (uint16_t) pkt.pkOrientation.orTwist;
+
+			#define sind(x) sin(fmod(x, 360) * M_PI / 180)
+			#define cosd(x) cos(fmod(x, 360) * M_PI / 180)
+			double azimuth  = 90.0 + pkt.pkOrientation.orAzimuth  / 10.0;
+			double altitude = 90.0 - pkt.pkOrientation.orAltitude / 10.0;
+			evt.pen.tiltX = (int8_t) (-sind(altitude) * cosd(azimuth) * 90.0);
+			evt.pen.tiltY = (int8_t) (-sind(altitude) * sind(azimuth) * 90.0);
+			
+			if (pkt.pkStatus & TPS_INVERT)
+				evt.pen.flags |= MTY_PEN_FLAG_INVERTED;
+
+			BYTE buttons = 0;
+			app->wintab->InfoA(WTI_CURSORS + pkt.pkCursor, CSR_BUTTONS, &buttons);
+
+			BYTE mapping[32] = {0};
+			app->wintab->InfoA(WTI_CURSORS + pkt.pkCursor, CSR_SYSBTNMAP, &mapping);
+
+			for (uint8_t i = 0; i < buttons; i++) {
+				bool pressed      = pkt.pkButtons & (1 << i);
+				bool prev_pressed = app->wintab->prev_buttons & (1 << i);
+
+				bool right_click  = mapping[i] == SBN_RCLICK    || mapping[i] == SBN_RDBLCLICK;
+				bool double_click = mapping[i] == SBN_LDBLCLICK || mapping[i] == SBN_RDBLCLICK;
+
+				if (pressed && mapping[i] != SBN_NONE)
+					evt.pen.flags |= MTY_PEN_FLAG_TOUCHING;
+
+				if (right_click && (pressed || prev_pressed))
+					evt.pen.flags |= MTY_PEN_FLAG_BARREL;
+
+				if (double_click)
+					evt.pen.pressure = 1024;
+			}
+
+			if (evt.pen.flags & MTY_PEN_FLAG_TOUCHING && evt.pen.flags & MTY_PEN_FLAG_INVERTED)
+				evt.pen.flags |= MTY_PEN_FLAG_ERASER;
+
+			app->wintab->prev_evt     = evt.pen;
+			app->wintab->prev_buttons = pkt.pkButtons;
+
+			break;
+		}
+		case WT_PACKETEXT: {
+			if (!app->wintab)
+				break;
+
+			PACKETEXT pktext = {0};
+			app->wintab->Packet((HCTX) lparam, (UINT) wparam, &pktext);
+
+			evt.type = MTY_EVENT_WINTAB;
+			
+			evt.wintab.device = pktext.pkExpKeys.nTablet;
+
+			evt.wintab.type    = MTY_WINTAB_TYPE_KEY;
+			evt.wintab.control = pktext.pkExpKeys.nControl;
+			evt.wintab.state   = (uint8_t) pktext.pkExpKeys.nState;
+
+			SLIDERDATA *curr_ring = &pktext.pkTouchRing;
+			SLIDERDATA *prev_ring = &app->wintab->prev_pktext.pkTouchRing;
+			if (curr_ring->nPosition != prev_ring->nPosition || curr_ring->nMode != prev_ring->nMode) {
+				evt.wintab.type     = MTY_WINTAB_TYPE_RING;
+				evt.wintab.control  = curr_ring->nControl;
+				evt.wintab.state    = curr_ring->nMode;
+				evt.wintab.position = (uint16_t) curr_ring->nPosition;
+			}
+			
+			SLIDERDATA *curr_strip = &pktext.pkTouchStrip;
+			SLIDERDATA *prev_strip = &app->wintab->prev_pktext.pkTouchStrip;
+			if (curr_strip->nPosition != prev_strip->nPosition || curr_strip->nMode != prev_strip->nMode) {
+				evt.wintab.type     = MTY_WINTAB_TYPE_STRIP;
+				evt.wintab.control  = curr_strip->nControl;
+				evt.wintab.state    = curr_strip->nMode;
+				evt.wintab.position = (uint16_t) curr_strip->nPosition;
+			}
+
+			app->wintab->prev_pktext = pktext;
+
+			break;
+		}
+		case WT_PROXIMITY:
+			if (!app->wintab)
+				break;
+
+			app->pen_in_range = LOWORD(lparam) != 0;
+
+			if (!app->pen_in_range) {
+				evt.type = MTY_EVENT_PEN;
+				evt.pen = app->wintab->prev_evt;
+				evt.pen.flags |= MTY_PEN_FLAG_LEAVE;
+			}
+
+			break;
+		case WT_INFOCHANGE:
+			app_wintab_destroy(app, false);
+			app_wintab_create(app);
+
 			break;
 	}
 
@@ -1037,6 +1404,8 @@ void MTY_AppDestroy(MTY_App **app)
 		return;
 
 	MTY_App *ctx = *app;
+
+	app_wintab_destroy(ctx, true);
 
 	if (ctx->custom_cursor)
 		DestroyIcon(ctx->custom_cursor);
@@ -1578,6 +1947,24 @@ bool MTY_AppIsPenEnabled(MTY_App *ctx)
 void MTY_AppEnablePen(MTY_App *ctx, bool enable)
 {
 	ctx->pen_enabled = enable;
+
+	if (ctx->pen_enabled) {
+		app_wintab_create(ctx);
+	
+	} else {
+		app_wintab_destroy(ctx, true);
+	}
+}
+
+void MTY_AppOverrideTabletControls(MTY_App *ctx, bool override)
+{
+	if (!ctx->wintab)
+		return;
+
+	ctx->wintab->override = override;
+
+	app_wintab_destroy(ctx, false);
+	app_wintab_create(ctx);
 }
 
 MTY_InputMode MTY_AppGetInputMode(MTY_App *ctx)

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -965,11 +965,12 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 			break;
 		}
 		case WT_PROXIMITY:
-			if (app)
+			if (app && app->wintab)
 				wintab_on_proximity(app->wintab, &evt, lparam);
 			break;
 		case WT_INFOCHANGE:
-			wintab_recreate(&app->wintab, app_get_main_hwnd(app));
+			if (app)
+				wintab_recreate(&app->wintab, app_get_main_hwnd(app));
 			break;
 
 	}

--- a/src/windows/appw.c
+++ b/src/windows/appw.c
@@ -959,7 +959,7 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 				break;
 
 			PACKETEXT pktext = {0};
-			wintab_get_packetext(app->wintab, wparam, lparam, &pktext);
+			wintab_get_packet(app->wintab, wparam, lparam, &pktext);
 			wintab_on_packetext(app->wintab, &evt, &pktext);
 
 			break;
@@ -969,7 +969,7 @@ static LRESULT app_custom_hwnd_proc(struct window *ctx, HWND hwnd, UINT msg, WPA
 				wintab_on_proximity(app->wintab, &evt, lparam);
 			break;
 		case WT_INFOCHANGE:
-			wintab_recreate(&app->wintab);
+			wintab_recreate(&app->wintab, app_get_main_hwnd(app));
 			break;
 
 	}
@@ -1677,10 +1677,10 @@ void MTY_AppEnablePen(MTY_App *ctx, bool enable)
 {
 	ctx->pen_enabled = enable;
 
-	if (ctx->pen_enabled && !ctx->wintab) {
+	if (enable && !ctx->wintab) {
 		ctx->wintab = wintab_create(app_get_main_hwnd(ctx));
 	
-	} else if (ctx->wintab) {
+	} else if (!enable && ctx->wintab) {
 		wintab_destroy(&ctx->wintab, true);
 	}
 }
@@ -1689,7 +1689,7 @@ void MTY_AppOverrideTabletControls(MTY_App *ctx, bool override)
 {
 	wintab_override_controls(ctx->wintab, override);
 
-	wintab_recreate(&ctx->wintab);
+	wintab_recreate(&ctx->wintab, app_get_main_hwnd(ctx));
 }
 
 MTY_InputMode MTY_AppGetInputMode(MTY_App *ctx)

--- a/src/windows/wintab.c
+++ b/src/windows/wintab.c
@@ -1,0 +1,309 @@
+#include <windows.h>
+#include <windowsx.h>
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+
+#include "matoya.h"
+#include "wintab.h"
+
+typedef UINT(API *WTINFOA)(UINT, UINT, LPVOID);
+typedef HCTX(API *WTOPENA)(HWND, LPLOGCONTEXTA, BOOL);
+typedef BOOL(API *WTCLOSE)(HCTX);
+typedef BOOL(API *WTPACKET)(HCTX, UINT, LPVOID);
+typedef BOOL(API *WTEXTGET)(HCTX, UINT, LPVOID);
+typedef BOOL(API *WTEXTSET)(HCTX, UINT, LPVOID);
+
+static struct wt {
+	MTY_SO *instance;
+
+	WTINFOA  info;
+	WTOPENA  open;
+	WTCLOSE  close;
+	WTPACKET packet;
+	WTEXTGET ext_get;
+	WTEXTSET ext_set;
+} wt;
+
+struct wintab
+{
+	HWND hwnd;
+	HCTX context;
+	MTY_PenEvent prev_evt;
+	PACKETEXT prev_pktext;
+	DWORD prev_buttons;
+
+	bool override;
+	int32_t min_altitude;
+	int32_t max_altitude;
+	int32_t max_pressure;
+};
+
+static bool wintab_find_extension(struct wintab *ctx, uint32_t searched_tag, uint32_t *index)
+{
+	uint32_t current;
+
+	for (uint32_t i = 0; wt.info(WTI_EXTENSIONS + i, EXT_TAG, &current); i++)
+	{
+		if (current != searched_tag)
+			continue;
+
+		*index = i;
+		return true;
+	}
+
+	return false;
+}
+
+static void wintab_override_extension(struct wintab *ctx, uint8_t tablet_i, uint32_t extension)
+{
+	// Retrieve the number of controls for the given extension
+	EXTPROPERTY props = {0};
+	props.propertyID = TABLET_PROPERTY_CONTROLCOUNT;
+	props.tabletIndex = tablet_i;
+
+	if (!wt.ext_get(ctx->context, extension, &props))
+		return;
+	uint8_t controls = props.data[0];
+
+	for (uint8_t control_i = 0; control_i < controls; control_i++) {
+		// Retrieve the number of functions for the current control
+		props.propertyID = TABLET_PROPERTY_FUNCCOUNT;
+		props.controlIndex = control_i;
+
+		if (!wt.ext_get(ctx->context, extension, &props))
+			return;
+		uint8_t functions = props.data[0];
+
+		for (uint8_t function_i = 0; function_i < functions; function_i++) {
+			// Mark the current function as overriden by the application
+			props.propertyID = TABLET_PROPERTY_OVERRIDE;
+			props.functionIndex = function_i;
+			props.dataSize = sizeof(bool);
+			props.data[0] = ctx->override;
+
+			wt.ext_set(ctx->context, extension, &props);
+		}
+	}
+}
+
+struct wintab *wintab_create(HWND hwnd)
+{
+	bool r = false;
+
+	struct wintab *ctx = MTY_Alloc(1, sizeof(struct wintab));
+	if (!ctx)
+		goto except;
+
+	// Symbols are preserved between runtime destructions, so we only initialize them once
+	if (!wt.instance) {
+		wt.instance = MTY_SOLoad("Wintab32.dll");
+		if (!wt.instance)
+			goto except;
+
+		#define MAP(type, sym, func) \
+			wt.##func = (type)MTY_SOGetSymbol(wt.instance, "WT" #sym); \
+			if (!wt.##func) goto except;
+
+		MAP(WTINFOA,  InfoA , info);
+		MAP(WTOPENA,  OpenA , open);
+		MAP(WTCLOSE,  Close , close);
+		MAP(WTPACKET, Packet, packet);
+		MAP(WTEXTGET, ExtGet, ext_get);
+		MAP(WTEXTSET, ExtSet, ext_set);
+
+		if (!wt.info(0, 0, NULL))
+			goto except;
+	}
+
+	ctx->hwnd = hwnd;
+
+	// Retrieve a default system context from Wintab
+	LOGCONTEXTA lc = {0};
+	wt.info(WTI_DEFSYSCTX, 0, &lc);
+
+	uint32_t touch_strip_i = 0,    touch_ring_i = 0,    exp_keys_i = 0;
+	uint32_t touch_strip_mask = 0, touch_ring_mask = 0, exp_keys_mask = 0;
+
+	if (wintab_find_extension(ctx, WTX_TOUCHSTRIP, &touch_strip_i))
+		wt.info(WTI_EXTENSIONS + touch_strip_i, EXT_MASK, &touch_strip_mask);
+
+	if (wintab_find_extension(ctx, WTX_TOUCHRING, &touch_ring_i))
+		wt.info(WTI_EXTENSIONS + touch_ring_i, EXT_MASK, &touch_ring_mask);
+
+	if (wintab_find_extension(ctx, WTX_EXPKEYS2, &exp_keys_i))
+		wt.info(WTI_EXTENSIONS + exp_keys_i, EXT_MASK, &exp_keys_mask);
+
+	lc.lcOptions = CXO_MESSAGES | CXO_SYSTEM;
+	lc.lcPktData = PACKETDATA | touch_strip_mask | touch_ring_mask | exp_keys_mask;
+	lc.lcOutExtY = -lc.lcOutExtY;
+
+	ctx->context = wt.open(hwnd, &lc, TRUE);
+	if (!ctx->context)
+		goto except;
+
+	// Wintab only supports up to 16 devices working at the same time
+	for (uint8_t i = 0; i < 16; i++) {
+		if (!wt.info(WTI_DDCTXS + i, 0, NULL))
+			break;
+
+		wintab_override_extension(ctx, i, WTX_TOUCHSTRIP);
+		wintab_override_extension(ctx, i, WTX_TOUCHRING);
+		wintab_override_extension(ctx, i, WTX_EXPKEYS2);
+	}
+
+	AXIS ncaps = {0};
+	wt.info(WTI_DEVICES, DVC_NPRESSURE, &ncaps);
+	ctx->max_pressure = ncaps.axMax;
+
+	AXIS ocaps[3] = {0};
+	wt.info(WTI_DEVICES, DVC_ORIENTATION, &ocaps);
+	ctx->min_altitude = ocaps[1].axMin;
+	ctx->max_altitude = ocaps[1].axMax;
+
+	r = true;
+
+	except:
+
+	if (!r)
+		wintab_destroy(&ctx, true);
+
+	return ctx;
+}
+
+void wintab_recreate(struct wintab **ctx)
+{
+	HWND hwnd = (*ctx)->hwnd;
+	wintab_destroy(ctx, false);
+	*ctx = wintab_create(hwnd);
+}
+
+void wintab_destroy(struct wintab **ctx, bool unload)
+{
+	if (!(*ctx))
+		return;
+
+	if ((*ctx)->context) {
+		wt.close((*ctx)->context);
+		(*ctx)->context = NULL;
+	}
+
+	if (unload && wt.instance) {
+		MTY_SOUnload(&wt.instance);
+		wt = (struct wt) {0};
+	}
+
+	MTY_Free(*ctx);
+	*ctx = NULL;
+}
+
+void wintab_override_controls(struct wintab *ctx, bool override)
+{
+	ctx->override = override;
+}
+
+void wintab_get_packet(struct wintab *ctx, WPARAM wparam, LPARAM lparam, PACKET *pkt)
+{
+	wt.packet((HCTX) lparam, (UINT) wparam, pkt);
+}
+
+void wintab_get_packetext(struct wintab *ctx, WPARAM wparam, LPARAM lparam, PACKETEXT *pktext)
+{
+	wt.packet((HCTX) lparam, (UINT) wparam, pktext);
+}
+
+void wintab_on_packet(struct wintab *ctx, MTY_Event *evt, PACKET *pkt, MTY_Window window)
+{
+	evt->type = MTY_EVENT_PEN;
+	evt->window = window;
+
+	evt->pen.x = (uint16_t) pkt->pkX;
+	evt->pen.y = (uint16_t) pkt->pkY;
+	evt->pen.z = (uint16_t) pkt->pkZ;
+
+	evt->pen.pressure = (uint16_t) (pkt->pkNormalPressure / (double)ctx->max_pressure * 1024.0);
+	evt->pen.rotation = (uint16_t) pkt->pkOrientation.orTwist;
+
+	#define sind(x) sin(fmod(x, 360) * M_PI / 180)
+	#define cosd(x) cos(fmod(x, 360) * M_PI / 180)
+	double azimuth  = 90.0 + pkt->pkOrientation.orAzimuth  / 10.0;
+	double altitude = 90.0 - pkt->pkOrientation.orAltitude / 10.0;
+	evt->pen.tiltX = (int8_t) (-sind(altitude) * cosd(azimuth) * 90.0);
+	evt->pen.tiltY = (int8_t) (-sind(altitude) * sind(azimuth) * 90.0);
+
+	if (pkt->pkStatus & TPS_INVERT)
+		evt->pen.flags |= MTY_PEN_FLAG_INVERTED;
+
+	BYTE buttons = 0;
+	wt.info(WTI_CURSORS + pkt->pkCursor, CSR_BUTTONS, &buttons);
+
+	BYTE mapping[32] = {0};
+	wt.info(WTI_CURSORS + pkt->pkCursor, CSR_SYSBTNMAP, &mapping);
+
+	for (uint8_t i = 0; i < buttons; i++) {
+		bool pressed      = pkt->pkButtons & (1 << i);
+		bool prev_pressed = ctx->prev_buttons & (1 << i);
+
+		bool right_click  = mapping[i] == SBN_RCLICK    || mapping[i] == SBN_RDBLCLICK;
+		bool double_click = mapping[i] == SBN_LDBLCLICK || mapping[i] == SBN_RDBLCLICK;
+
+		if (pressed && mapping[i] != SBN_NONE)
+			evt->pen.flags |= MTY_PEN_FLAG_TOUCHING;
+
+		if (right_click && (pressed || prev_pressed))
+			evt->pen.flags |= MTY_PEN_FLAG_BARREL;
+
+		if (double_click)
+			evt->pen.pressure = 1024;
+	}
+
+	if (evt->pen.flags & MTY_PEN_FLAG_TOUCHING && evt->pen.flags & MTY_PEN_FLAG_INVERTED)
+		evt->pen.flags |= MTY_PEN_FLAG_ERASER;
+
+	ctx->prev_evt     = evt->pen;
+	ctx->prev_buttons = pkt->pkButtons;
+}
+
+void wintab_on_packetext(struct wintab *ctx, MTY_Event *evt, PACKETEXT *pktext)
+{
+	evt->type = MTY_EVENT_WINTAB;
+
+	evt->wintab.device = pktext->pkExpKeys.nTablet;
+
+	evt->wintab.type    = MTY_WINTAB_TYPE_KEY;
+	evt->wintab.control = pktext->pkExpKeys.nControl;
+	evt->wintab.state   = (uint8_t) pktext->pkExpKeys.nState;
+
+	SLIDERDATA *curr_ring = &pktext->pkTouchRing;
+	SLIDERDATA *prev_ring = &ctx->prev_pktext.pkTouchRing;
+	if (curr_ring->nPosition != prev_ring->nPosition || curr_ring->nMode != prev_ring->nMode) {
+		evt->wintab.type     = MTY_WINTAB_TYPE_RING;
+		evt->wintab.control  = curr_ring->nControl;
+		evt->wintab.state    = curr_ring->nMode;
+		evt->wintab.position = (uint16_t) curr_ring->nPosition;
+	}
+
+	SLIDERDATA *curr_strip = &pktext->pkTouchStrip;
+	SLIDERDATA *prev_strip = &ctx->prev_pktext.pkTouchStrip;
+	if (curr_strip->nPosition != prev_strip->nPosition || curr_strip->nMode != prev_strip->nMode) {
+		evt->wintab.type     = MTY_WINTAB_TYPE_STRIP;
+		evt->wintab.control  = curr_strip->nControl;
+		evt->wintab.state    = curr_strip->nMode;
+		evt->wintab.position = (uint16_t) curr_strip->nPosition;
+	}
+
+	ctx->prev_pktext = *pktext;
+}
+
+bool wintab_on_proximity(struct wintab *ctx, MTY_Event *evt, LPARAM lparam)
+{
+	bool pen_in_range = LOWORD(lparam) != 0;
+
+	if (!pen_in_range) {
+		evt->type = MTY_EVENT_PEN;
+		evt->pen = ctx->prev_evt;
+		evt->pen.flags |= MTY_PEN_FLAG_LEAVE;
+	}
+
+	return pen_in_range;
+}

--- a/src/windows/wintab.c
+++ b/src/windows/wintab.c
@@ -35,7 +35,7 @@ struct wintab
 
 static bool wintab_find_extension(struct wintab *ctx, uint32_t searched_tag, uint32_t *index)
 {
-	uint32_t current;
+	uint32_t current = 0;
 
 	for (uint32_t i = 0; wt.info(WTI_EXTENSIONS + i, EXT_TAG, &current); i++) {
 		if (current != searched_tag)
@@ -57,6 +57,7 @@ static void wintab_override_extension(struct wintab *ctx, uint8_t tablet_i, uint
 
 	if (!wt.ext_get(ctx->context, extension, &props))
 		return;
+
 	uint8_t controls = props.data[0];
 
 	for (uint8_t control_i = 0; control_i < controls; control_i++) {
@@ -66,6 +67,7 @@ static void wintab_override_extension(struct wintab *ctx, uint8_t tablet_i, uint
 
 		if (!wt.ext_get(ctx->context, extension, &props))
 			continue;
+
 		uint8_t functions = props.data[0];
 
 		for (uint8_t function_i = 0; function_i < functions; function_i++) {
@@ -95,7 +97,7 @@ struct wintab *wintab_create(HWND hwnd)
 			goto except;
 
 		#define MAP(type, sym, func) \
-			wt.##func = (type)MTY_SOGetSymbol(wt.instance, "WT" #sym); \
+			wt.##func = (type) MTY_SOGetSymbol(wt.instance, "WT" #sym); \
 			if (!wt.##func) goto except;
 
 		MAP(WTINFOA,  InfoA , info);

--- a/src/windows/wintab.h
+++ b/src/windows/wintab.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#define PACKETDATA       (PK_CONTEXT | PK_STATUS | PK_TIME | PK_CHANGED | PK_SERIAL_NUMBER | PK_CURSOR | PK_BUTTONS |\
+                          PK_X | PK_Y | PK_Z | PK_NORMAL_PRESSURE | PK_TANGENT_PRESSURE | PK_ORIENTATION | PK_ROTATION)
+#define PACKETEXPKEYS    PKEXT_ABSOLUTE
+#define PACKETTOUCHSTRIP PKEXT_ABSOLUTE
+#define PACKETTOUCHRING  PKEXT_ABSOLUTE
+
+#include "wintab/MSGPACK.H"
+#include "wintab/WINTAB.H"
+#include "wintab/PKTDEF.H"
+
+struct wintab;
+
+struct wintab *wintab_create(HWND hwnd);
+void wintab_recreate(struct wintab **ctx);
+void wintab_destroy(struct wintab **ctx, bool unload);
+
+void wintab_override_controls(struct wintab *ctx, bool override);
+
+void wintab_get_packet(struct wintab *ctx, WPARAM wparam, LPARAM lparam, PACKET *pkt);
+void wintab_get_packetext(struct wintab *ctx, WPARAM wparam, LPARAM lparam, PACKETEXT *pktext);
+
+void wintab_on_packet(struct wintab *ctx, MTY_Event *evt, PACKET *pkt, MTY_Window window);
+void wintab_on_packetext(struct wintab *ctx, MTY_Event *evt, PACKETEXT *pktext);
+bool wintab_on_proximity(struct wintab *ctx, MTY_Event *evt, LPARAM lparam);

--- a/src/windows/wintab.h
+++ b/src/windows/wintab.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <windows.h>
+#include <stdbool.h>
+
+// Those defines are required to configure wintab/*.h headers
 #define PACKETDATA       (PK_CONTEXT | PK_STATUS | PK_TIME | PK_CHANGED | PK_SERIAL_NUMBER | PK_CURSOR | PK_BUTTONS |\
                           PK_X | PK_Y | PK_Z | PK_NORMAL_PRESSURE | PK_TANGENT_PRESSURE | PK_ORIENTATION | PK_ROTATION)
 #define PACKETEXPKEYS    PKEXT_ABSOLUTE
@@ -13,14 +17,13 @@
 struct wintab;
 
 struct wintab *wintab_create(HWND hwnd);
-void wintab_recreate(struct wintab **ctx);
-void wintab_destroy(struct wintab **ctx, bool unload);
+void wintab_recreate(struct wintab **ctx, HWND hwnd);
+void wintab_destroy(struct wintab **wintab, bool unload_symbols);
 
 void wintab_override_controls(struct wintab *ctx, bool override);
 
-void wintab_get_packet(struct wintab *ctx, WPARAM wparam, LPARAM lparam, PACKET *pkt);
-void wintab_get_packetext(struct wintab *ctx, WPARAM wparam, LPARAM lparam, PACKETEXT *pktext);
+void wintab_get_packet(struct wintab *ctx, WPARAM wparam, LPARAM lparam, void *pkt);
 
-void wintab_on_packet(struct wintab *ctx, MTY_Event *evt, PACKET *pkt, MTY_Window window);
-void wintab_on_packetext(struct wintab *ctx, MTY_Event *evt, PACKETEXT *pktext);
+void wintab_on_packet(struct wintab *ctx, MTY_Event *evt, const PACKET *pkt, MTY_Window window);
+void wintab_on_packetext(struct wintab *ctx, MTY_Event *evt, const PACKETEXT *pktext);
 bool wintab_on_proximity(struct wintab *ctx, MTY_Event *evt, LPARAM lparam);


### PR DESCRIPTION
This PR adds support for Wintab-compatible devices (mostly Wacom) in Windows applications.
* The support is optional and transparent: Windows applications will check if `Wintab32.dll` is installed on the system (which comes with the Wacom driver), and will fallback to WinInk if not.
* A call to `MTY_AppEnablePen` is still required to enable pen on an application, whether Wintab is available or not.
* New method `MTY_AppOverrideTabletControls` added: when enabled, extended tablet inputs (e.g. ExpressKeys) are overriden by the application and received as `MTY_EVENT_WINTAB` instead of executing the driver-configured macros.
* Z-axis is now exposed in `MTY_EVENT_PEN` when this data is available.
* Those changes also includes a minor adjustment on WinInk right click: the button up flag is now properly set.