### PR TITLE
[android-zoom] Add MTY_COLOR_FORMAT_RGBA

### DIFF
--- a/src/gfx/gl.c
+++ b/src/gfx/gl.c
@@ -191,7 +191,7 @@ static void gl_reload_textures(struct gl *ctx, const void *image, const MTY_Rend
 			GLenum internal = GL_BGRA;
 			GLenum format = GL_BGRA;
 			GLenum type = GL_UNSIGNED_BYTE;
-			GLint bpp = sizeof(uint32_t);
+			GLint bpp = 4;
 
 			if (desc->format == MTY_COLOR_FORMAT_RGBA) {
 				internal = GL_RGBA;
@@ -201,11 +201,11 @@ static void gl_reload_textures(struct gl *ctx, const void *image, const MTY_Rend
 				internal = GL_RGB;
 				format = GL_RGB;
 				type = GL_UNSIGNED_SHORT_5_6_5;
-				bpp = sizeof(uint16_t);
+				bpp = 2;
 
 			} else if (desc->format == MTY_COLOR_FORMAT_BGRA5551) {
 				type = GL_UNSIGNED_SHORT_1_5_5_5_REV;
-				bpp = sizeof(uint16_t);
+				bpp = 2;
 			}
 
 			// BGRA

--- a/src/gfx/gl.c
+++ b/src/gfx/gl.c
@@ -184,23 +184,28 @@ static void gl_reload_textures(struct gl *ctx, const void *image, const MTY_Rend
 {
 	switch (desc->format) {
 		case MTY_COLOR_FORMAT_BGRA:
+		case MTY_COLOR_FORMAT_RGBA: 
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
 		case MTY_COLOR_FORMAT_BGRA5551: {
-			GLenum internal = GL_RGBA;
+			GLenum internal = GL_BGRA;
 			GLenum format = GL_BGRA;
 			GLenum type = GL_UNSIGNED_BYTE;
-			GLint bpp = 4;
+			GLint bpp = sizeof(uint32_t);
 
-			if (desc->format == MTY_COLOR_FORMAT_BGR565) {
+			if (desc->format == MTY_COLOR_FORMAT_RGBA) {
+				internal = GL_RGBA;
+				format = GL_RGBA;
+
+			} else if (desc->format == MTY_COLOR_FORMAT_BGR565) {
 				internal = GL_RGB;
 				format = GL_RGB;
 				type = GL_UNSIGNED_SHORT_5_6_5;
-				bpp = 2;
+				bpp = sizeof(uint16_t);
 
 			} else if (desc->format == MTY_COLOR_FORMAT_BGRA5551) {
 				type = GL_UNSIGNED_SHORT_1_5_5_5_REV;
-				bpp = 2;
+				bpp = sizeof(uint16_t);
 			}
 
 			// BGRA

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -70,6 +70,7 @@ typedef enum {
 	MTY_COLOR_FORMAT_BGR565   = 6, ///< 5-bits blue, 6-bits green, 5-bits red.
 	MTY_COLOR_FORMAT_BGRA5551 = 7, ///< 5-bits per BGR channels, 1-bit alpha.
 	MTY_COLOR_FORMAT_AYUV     = 8, ///< 4:4:4 full W/H interleaved Y, U, V.
+	MTY_COLOR_FORMAT_RGBA     = 9, ///< 8-bits per channel RGBA.
 	MTY_COLOR_FORMAT_MAKE_32 = INT32_MAX,
 } MTY_ColorFormat;
 

--- a/src/unix/apple/gfx/metal.m
+++ b/src/unix/apple/gfx/metal.m
@@ -157,11 +157,18 @@ static void metal_reload_textures(struct metal *ctx, id<MTLDevice> device, const
 {
 	switch (desc->format) {
 		case MTY_COLOR_FORMAT_BGRA:
+		case MTY_COLOR_FORMAT_RGBA:
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
 		case MTY_COLOR_FORMAT_BGRA5551: {
-			MTLPixelFormat format = MTLPixelFormatBGRA8Unorm;
-			uint8_t bpp = (desc->format == MTY_COLOR_FORMAT_BGRA || desc->format == MTY_COLOR_FORMAT_AYUV) ? 4 : 2;
+			MTLPixelFormat format = desc->format == MTY_COLOR_FORMAT_RGBA
+				? MTLPixelFormatRGBA8Unorm
+				: MTLPixelFormatBGRA8Unorm;
+			uint8_t bpp =
+				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
+				sizeof(uint16_t);
 
 			// 16-bit packed pixel formats were not available until Big Sur
 			if (bpp == 2) {

--- a/src/unix/apple/gfx/metal.m
+++ b/src/unix/apple/gfx/metal.m
@@ -165,10 +165,10 @@ static void metal_reload_textures(struct metal *ctx, id<MTLDevice> device, const
 				? MTLPixelFormatRGBA8Unorm
 				: MTLPixelFormatBGRA8Unorm;
 			uint8_t bpp =
-				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
-				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
-				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
-				sizeof(uint16_t);
+				desc->format == MTY_COLOR_FORMAT_BGRA ? 4 :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? 4 :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? 4 :
+				2;
 
 			// 16-bit packed pixel formats were not available until Big Sur
 			if (bpp == 2) {

--- a/src/windows/gfx/d3d11.c
+++ b/src/windows/gfx/d3d11.c
@@ -287,10 +287,10 @@ static HRESULT d3d11_reload_textures(struct d3d11 *ctx, ID3D11Device *device, ID
 				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? DXGI_FORMAT_B5G5R5A1_UNORM :
 				DXGI_FORMAT_B8G8R8A8_UNORM;
 			uint8_t bpp =
-				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
-				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
-				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
-				sizeof(uint16_t);
+				desc->format == MTY_COLOR_FORMAT_BGRA ? 4 :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? 4 :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? 4 :
+				2;
 
 			// BGRA
 			HRESULT e = d3d11_refresh_resource(&ctx->staging[0], device, format, desc->cropWidth, desc->cropHeight);

--- a/src/windows/gfx/d3d11.c
+++ b/src/windows/gfx/d3d11.c
@@ -277,12 +277,20 @@ static HRESULT d3d11_reload_textures(struct d3d11 *ctx, ID3D11Device *device, ID
 {
 	switch (desc->format) {
 		case MTY_COLOR_FORMAT_BGRA:
+		case MTY_COLOR_FORMAT_RGBA:
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
 		case MTY_COLOR_FORMAT_BGRA5551: {
-			DXGI_FORMAT format = desc->format == MTY_COLOR_FORMAT_BGR565 ? DXGI_FORMAT_B5G6R5_UNORM :
-				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? DXGI_FORMAT_B5G5R5A1_UNORM : DXGI_FORMAT_B8G8R8A8_UNORM;
-			uint8_t bpp = (desc->format == MTY_COLOR_FORMAT_BGRA || desc->format == MTY_COLOR_FORMAT_AYUV) ? 4 : 2;
+			DXGI_FORMAT format =
+				desc->format == MTY_COLOR_FORMAT_RGBA     ? DXGI_FORMAT_R8G8B8A8_UNORM :
+				desc->format == MTY_COLOR_FORMAT_BGR565   ? DXGI_FORMAT_B5G6R5_UNORM   :
+				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? DXGI_FORMAT_B5G5R5A1_UNORM :
+				DXGI_FORMAT_B8G8R8A8_UNORM;
+			uint8_t bpp =
+				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
+				sizeof(uint16_t);
 
 			// BGRA
 			HRESULT e = d3d11_refresh_resource(&ctx->staging[0], device, format, desc->cropWidth, desc->cropHeight);

--- a/src/windows/gfx/d3d12.c
+++ b/src/windows/gfx/d3d12.c
@@ -472,12 +472,20 @@ static HRESULT d3d12_reload_textures(struct d3d12 *ctx, ID3D12Device *device, ID
 {
 	switch (desc->format) {
 		case MTY_COLOR_FORMAT_BGRA:
+		case MTY_COLOR_FORMAT_RGBA:
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
 		case MTY_COLOR_FORMAT_BGRA5551: {
-			DXGI_FORMAT format = desc->format == MTY_COLOR_FORMAT_BGR565 ? DXGI_FORMAT_B5G6R5_UNORM :
-				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? DXGI_FORMAT_B5G5R5A1_UNORM : DXGI_FORMAT_B8G8R8A8_UNORM;
-			uint8_t bpp = (desc->format == MTY_COLOR_FORMAT_BGRA || desc->format == MTY_COLOR_FORMAT_AYUV) ? 4 : 2;
+			DXGI_FORMAT format =
+				desc->format == MTY_COLOR_FORMAT_RGBA     ? DXGI_FORMAT_R8G8B8A8_UNORM :
+				desc->format == MTY_COLOR_FORMAT_BGR565   ? DXGI_FORMAT_B5G6R5_UNORM   :
+				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? DXGI_FORMAT_B5G5R5A1_UNORM :
+				DXGI_FORMAT_B8G8R8A8_UNORM;
+			uint8_t bpp =
+				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
+				sizeof(uint16_t);
 
 			// BGRA
 			HRESULT e = d3d12_refresh_resource(&ctx->staging[0], device, format, desc->cropWidth, desc->cropHeight, bpp);

--- a/src/windows/gfx/d3d12.c
+++ b/src/windows/gfx/d3d12.c
@@ -482,10 +482,10 @@ static HRESULT d3d12_reload_textures(struct d3d12 *ctx, ID3D12Device *device, ID
 				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? DXGI_FORMAT_B5G5R5A1_UNORM :
 				DXGI_FORMAT_B8G8R8A8_UNORM;
 			uint8_t bpp =
-				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
-				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
-				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
-				sizeof(uint16_t);
+				desc->format == MTY_COLOR_FORMAT_BGRA ? 4 :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? 4 :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? 4 :
+				2;
 
 			// BGRA
 			HRESULT e = d3d12_refresh_resource(&ctx->staging[0], device, format, desc->cropWidth, desc->cropHeight, bpp);

--- a/src/windows/gfx/d3d9.c
+++ b/src/windows/gfx/d3d9.c
@@ -215,12 +215,20 @@ static HRESULT d3d9_reload_textures(struct d3d9 *ctx, IDirect3DDevice9 *device,
 {
 	switch (desc->format) {
 		case MTY_COLOR_FORMAT_BGRA:
+		case MTY_COLOR_FORMAT_RGBA:
 		case MTY_COLOR_FORMAT_AYUV:
 		case MTY_COLOR_FORMAT_BGR565:
 		case MTY_COLOR_FORMAT_BGRA5551: {
-			D3DFORMAT format = desc->format == MTY_COLOR_FORMAT_BGR565 ? D3DFMT_R5G6B5 :
-				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? D3DFMT_X1R5G5B5 : D3DFMT_A8R8G8B8;
-			uint8_t bpp = (desc->format == MTY_COLOR_FORMAT_BGRA || desc->format == MTY_COLOR_FORMAT_AYUV) ? 4 : 2;
+			D3DFORMAT format =
+				desc->format == MTY_COLOR_FORMAT_RGBA     ? D3DFMT_A8B8G8R8 :
+				desc->format == MTY_COLOR_FORMAT_BGR565   ? D3DFMT_R5G6B5   :
+				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? D3DFMT_X1R5G5B5 :
+				D3DFMT_A8R8G8B8;
+			uint8_t bpp =
+				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
+				sizeof(uint16_t);
 
 			// BGRA
 			HRESULT e = d3d9_refresh_resource(&ctx->staging[0], device, format, desc->cropWidth, desc->cropHeight);

--- a/src/windows/gfx/d3d9.c
+++ b/src/windows/gfx/d3d9.c
@@ -225,10 +225,10 @@ static HRESULT d3d9_reload_textures(struct d3d9 *ctx, IDirect3DDevice9 *device,
 				desc->format == MTY_COLOR_FORMAT_BGRA5551 ? D3DFMT_X1R5G5B5 :
 				D3DFMT_A8R8G8B8;
 			uint8_t bpp =
-				desc->format == MTY_COLOR_FORMAT_BGRA ? sizeof(uint32_t) :
-				desc->format == MTY_COLOR_FORMAT_RGBA ? sizeof(uint32_t) :
-				desc->format == MTY_COLOR_FORMAT_AYUV ? sizeof(uint32_t) :
-				sizeof(uint16_t);
+				desc->format == MTY_COLOR_FORMAT_BGRA ? 4 :
+				desc->format == MTY_COLOR_FORMAT_RGBA ? 4 :
+				desc->format == MTY_COLOR_FORMAT_AYUV ? 4 :
+				2;
 
 			// BGRA
 			HRESULT e = d3d9_refresh_resource(&ctx->staging[0], device, format, desc->cropWidth, desc->cropHeight);


### PR DESCRIPTION
Adds `MTY_COLOR_FORMAT_RGBA` which is required by the upcoming `MTY_Cursor` module. Also fixes `MTY_COLOR_FORMAT_BGRA`: in OpenGL ES, the `internal` and `format` parameters must match. 