### PR TITLE
[android-zoom] Position the frames with DrawQuad functions

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -47,8 +47,11 @@ void MTY_WindowDrawQuad(MTY_App *app, MTY_Window window, const void *image, cons
 	struct gfx_ctx *gfx_ctx = NULL;
 	MTY_GFX api = mty_window_get_gfx(app, window, &gfx_ctx);
 
+	MTY_RenderDesc mutated = *desc;
+	MTY_WindowGetSize(app, window, &mutated.displayWidth, &mutated.displayHeight);
+
 	if (api != MTY_GFX_NONE)
-		GFX_CTX_API[api].draw_quad(gfx_ctx, image, desc);
+		GFX_CTX_API[api].draw_quad(gfx_ctx, image, &mutated);
 }
 
 void MTY_WindowDrawUI(MTY_App *app, MTY_Window window, const MTY_DrawData *dd)

--- a/src/gfx/gl.c
+++ b/src/gfx/gl.c
@@ -277,9 +277,7 @@ bool mty_gl_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	float vpx, vpy, vpw, vph;
-	mty_viewport(desc->rotation, desc->cropWidth, desc->cropHeight,
-		desc->viewWidth, desc->viewHeight, desc->aspectRatio, desc->scale,
-		&vpx, &vpy, &vpw, &vph);
+	mty_viewport(desc, &vpx, &vpy, &vpw, &vph, true);
 
 	glViewport(lrint(vpx), lrint(vpy) + GL_ORIGIN_Y, lrint(vpw), lrint(vph));
 

--- a/src/gfx/viewport.h
+++ b/src/gfx/viewport.h
@@ -10,10 +10,10 @@
 
 static void mty_viewport(const MTY_RenderDesc *desc, float *vp_x, float *vp_y, float *vp_w, float *vp_h, bool transform_origin)
 {
-	float w      = (float)desc->cropWidth;
-	float h      = (float)desc->cropHeight;
-	float view_w = (float)desc->viewWidth;
-	float view_h = (float)desc->viewHeight;
+	float w      = (float) desc->cropWidth;
+	float h      = (float) desc->cropHeight;
+	float view_w = (float) desc->viewWidth;
+	float view_h = (float) desc->viewHeight;
 	float ar     = desc->aspectRatio;
 
 	if (desc->rotation == MTY_ROTATION_90 || desc->rotation == MTY_ROTATION_270) {

--- a/src/gfx/viewport.h
+++ b/src/gfx/viewport.h
@@ -8,36 +8,58 @@
 
 #include <math.h>
 
-static void mty_viewport(MTY_Rotation rotation, uint32_t w, uint32_t h,
-	uint32_t view_w, uint32_t view_h, float ar, float scale, float *vp_x,
-	float *vp_y, float *vp_w, float *vp_h)
+static void mty_viewport(const MTY_RenderDesc *desc, float *vp_x, float *vp_y, float *vp_w, float *vp_h, bool transform_origin)
 {
-	if (rotation == MTY_ROTATION_90 || rotation == MTY_ROTATION_270) {
-		uint32_t tmp = h;
+	float w      = (float)desc->cropWidth;
+	float h      = (float)desc->cropHeight;
+	float view_w = (float)desc->viewWidth;
+	float view_h = (float)desc->viewHeight;
+	float ar     = desc->aspectRatio;
+
+	if (desc->rotation == MTY_ROTATION_90 || desc->rotation == MTY_ROTATION_270) {
+		float tmp = h;
 		h = w;
 		w = tmp;
 		ar = 1.0f / ar;
 	}
 
-	uint32_t scaled_w = lrint(scale * (float) w);
-	uint32_t scaled_h = lrint(scale * (float) h);
+	float scaled_w = roundf(desc->scale * w);
+	float scaled_h = roundf(desc->scale * h);
 
-	if (scaled_w == 0 || scaled_h == 0 || view_w < scaled_w || view_h < scaled_h)
-		scaled_w = view_w;
+	switch (desc->type)	{
+		default:
+		case MTY_POSITION_AUTO:
+			if (scaled_w == 0 || scaled_h == 0 || view_w < scaled_w || view_h < scaled_h)
+				scaled_w = view_w;
 
-	*vp_w = (float) scaled_w;
-	*vp_h = roundf(*vp_w / ar);
+			*vp_w = scaled_w;
+			*vp_h = roundf(*vp_w / ar);
 
-	if (*vp_w > (float) view_w) {
-		*vp_w = (float) view_w;
-		*vp_h = roundf(*vp_w / ar);
+			if (*vp_w > view_w) {
+				*vp_w = view_w;
+				*vp_h = roundf(*vp_w / ar);
+			}
+
+			if (*vp_h > view_h) {
+				*vp_h = view_h;
+				*vp_w = roundf(*vp_h * ar);
+			}
+
+			*vp_x = (view_w - *vp_w) / 2.0f;
+			*vp_y = (view_h - *vp_h) / 2.0f;
+			break;
+		case MTY_POSITION_FIXED:
+			*vp_w = scaled_w;
+			*vp_h = scaled_h;
+
+			*vp_x = (float)desc->imageX;
+			*vp_y = (float)desc->imageY;
+
+			if (transform_origin)
+				*vp_y = desc->displayHeight - scaled_h - *vp_y;
+			break;
 	}
 
-	if (*vp_h > (float) view_h) {
-		*vp_h = (float) view_h;
-		*vp_w = roundf(*vp_h * ar);
-	}
-
-	*vp_x = roundf(((float) view_w - *vp_w) / 2.0f);
-	*vp_y = roundf(((float) view_h - *vp_h) / 2.0f);
+	*vp_x = roundf(*vp_x);
+	*vp_y = roundf(*vp_y);
 }

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -99,18 +99,30 @@ typedef enum {
 	MTY_ROTATION_MAKE_32 = INT32_MAX,
 } MTY_Rotation;
 
+/// @brief Quad position type.
+typedef enum {
+	MTY_POSITION_AUTO    = 0, ///< Automatic center positioning.
+	MTY_POSITION_FIXED   = 1, ///< Position using pixel values.
+	MTY_POSITION_MAKE_32 = INT32_MAX,
+} MTY_Position;
+
 /// @brief Description of a render operation.
 typedef struct {
 	MTY_ColorFormat format; ///< The color format of a raw image.
 	MTY_Rotation rotation;  ///< Rotation applied to the image.
 	MTY_Filter filter;      ///< Filter applied to the image.
 	MTY_Effect effect;      ///< Effect applied to the image.
+	MTY_Position type;      ///< Type of positioning configuration.
+	int32_t imageX;         ///< The horizontal position in pixels of the image.
+	int32_t imageY;         ///< The vertical position in pixels of the image.
 	uint32_t imageWidth;    ///< The width in pixels of the image.
 	uint32_t imageHeight;   ///< The height in pixels of the image.
 	uint32_t cropWidth;     ///< Desired crop width of the image from the top left corner.
 	uint32_t cropHeight;    ///< Desired crop height of the image from the top left corner.
 	uint32_t viewWidth;     ///< The width of the viewport.
 	uint32_t viewHeight;    ///< The height of the viewport.
+	uint32_t displayWidth;  ///< The current width of the window.
+	uint32_t displayHeight; ///< The current height of the window.
 	float aspectRatio;      ///< Desired aspect ratio of the image. The renderer will letterbox
 	                        ///<   the image to maintain the specified aspect ratio.
 	float scale;            ///< Multiplier applied to the dimensions of the image, producing an

--- a/src/unix/apple/gfx/metal.m
+++ b/src/unix/apple/gfx/metal.m
@@ -265,9 +265,7 @@ bool mty_metal_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	float vpx, vpy, vpw, vph;
-	mty_viewport(desc->rotation, desc->cropWidth, desc->cropHeight,
-		desc->viewWidth, desc->viewHeight, desc->aspectRatio, desc->scale,
-		&vpx, &vpy, &vpw, &vph);
+	mty_viewport(desc, &vpx, &vpy, &vpw, &vph, false);
 
 	MTLViewport vp = {0};
 	vp.originX = vpx;

--- a/src/windows/gfx/d3d11.c
+++ b/src/windows/gfx/d3d11.c
@@ -364,9 +364,7 @@ bool mty_d3d11_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	D3D11_VIEWPORT vp = {0};
-	mty_viewport(desc->rotation, desc->cropWidth, desc->cropHeight,
-		desc->viewWidth, desc->viewHeight, desc->aspectRatio, desc->scale,
-		&vp.TopLeftX, &vp.TopLeftY, &vp.Width, &vp.Height);
+	mty_viewport(desc, &vp.TopLeftX, &vp.TopLeftY, &vp.Width, &vp.Height, false);
 
 	ID3D11DeviceContext_RSSetViewports(_context, 1, &vp);
 

--- a/src/windows/gfx/d3d12.c
+++ b/src/windows/gfx/d3d12.c
@@ -560,9 +560,7 @@ bool mty_d3d12_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	D3D12_VIEWPORT vp = {0};
-	mty_viewport(desc->rotation, desc->cropWidth, desc->cropHeight,
-		desc->viewWidth, desc->viewHeight, desc->aspectRatio, desc->scale,
-		&vp.TopLeftX, &vp.TopLeftY, &vp.Width, &vp.Height);
+	mty_viewport(desc, &vp.TopLeftX, &vp.TopLeftY, &vp.Width, &vp.Height, false);
 
 	ID3D12GraphicsCommandList_RSSetViewports(cl, 1, &vp);
 

--- a/src/windows/gfx/d3d9.c
+++ b/src/windows/gfx/d3d9.c
@@ -315,9 +315,7 @@ bool mty_d3d9_render(struct gfx *gfx, MTY_Device *device, MTY_Context *context,
 
 	// Viewport
 	float vpx, vpy, vpw, vph;
-	mty_viewport(desc->rotation, desc->cropWidth, desc->cropHeight,
-		desc->viewWidth, desc->viewHeight, desc->aspectRatio, desc->scale,
-		&vpx, &vpy, &vpw, &vph);
+	mty_viewport(desc, &vpx, &vpy, &vpw, &vph, false);
 
 	D3DVIEWPORT9 vp = {0};
 	vp.X = lrint(vpx);


### PR DESCRIPTION
Required by the upcoming zoom feature, which require contextual positioning of each quad.

`MTY_Position` has been created to define how a frame is displayed on the screen. It defaults to `MTY_POSITION_AUTO`, which is the original behavior. When `MTY_POSITION_FIXED` is set, `imageX` and `imageY` can be set to position the frame. In this mode, automatic scaling is disabled and must be set in the `scale` property by the client.

Note: In OpenGL, `windowWidth` and `windowHeight` must be set on `MTY_DrawDesc`. This is done automatically in `MTY_WindowDrawQuad`.