### PR TITLE
[android-zoom] Add MTY_ScaleEvent

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -148,6 +148,8 @@ void MTY_PrintEvent(const MTY_Event *evt)
 		PEVENT(MTY_EVENT_HOTKEY, evt, "id: %u", evt->hotkey);
 		PEVENT(MTY_EVENT_TEXT, evt, "text: %s", evt->text);
 		PEVENT(MTY_EVENT_SCROLL, evt, "x: %d, y: %d, pixels: %u", evt->scroll.x, evt->scroll.y, evt->scroll.pixels);
+		PEVENT(MTY_EVENT_SCALE, evt, "factor: %f, focusX: %f, focusY: %f", evt->scale.factor, 
+			evt->scale.focusX, evt->scale.focusY);
 		PEVENT(MTY_EVENT_FOCUS, evt, "focus: %u", evt->focus);
 		PEVENT(MTY_EVENT_MOTION, evt, "x: %d, y: %d, relative: %u, synth: %u", evt->motion.x,
 			evt->motion.y, evt->motion.relative, evt->motion.synth);

--- a/src/matoya.h
+++ b/src/matoya.h
@@ -337,6 +337,7 @@ typedef enum {
 	MTY_EVENT_BACK         = 19, ///< The mobile back command has been triggered.
 	MTY_EVENT_SIZE         = 20, ///< The size of a window has changed.
 	MTY_EVENT_MOVE         = 21, ///< The window's top left corner has moved.
+	MTY_EVENT_SCALE        = 22, ///< The scale factor has been changed.
 	MTY_EVENT_MAKE_32      = INT32_MAX,
 } MTY_EventType;
 
@@ -617,6 +618,20 @@ typedef enum {
 	MTY_CONTEXT_STATE_MAKE_32 = INT32_MAX,
 } MTY_ContextState;
 
+typedef enum {
+	MTY_MOTION_FLAG_START    = 0x01, ///< Motion event has started.
+	MTY_MOTION_FLAG_TOUCH    = 0x02, ///< Motion event comes from a touch event.
+	MTY_MOTION_FLAG_MAKE_32  = INT32_MAX,
+} MTY_MotionFlag;
+
+/// @brief State of a scaling gesture.
+typedef enum {
+	MTY_SCALE_STATE_ONGOING = 0, ///< The scaling gesture is in progress.
+	MTY_SCALE_STATE_START   = 1, ///< The scaling gesture has just started.
+	MTY_SCALE_STATE_STOP    = 2, ///< The scaling gesture has just ended.
+	MTY_SCALE_STATE_MAKE_32 = INT32_MAX,
+} MTY_ScaleState;
+
 /// @brief Key event.
 typedef struct {
 	MTY_Key key;  ///< The key that has been pressed or released.
@@ -631,6 +646,14 @@ typedef struct {
 	bool pixels; ///< The scroll values are expressed in exact pixels.
 } MTY_ScrollEvent;
 
+/// @brief Scale event.
+typedef struct {
+	MTY_ScaleState state; ///< Current state of the scaling gesture.
+	float factor;         ///< The relative scale factor.
+	float focusX;         ///< The horizontal focal point position.
+	float focusY;         ///< The vertical focal point position.
+} MTY_ScaleEvent;
+
 /// @brief Button event.
 typedef struct {
 	MTY_Button button; ///< The button that has been pressed or released.
@@ -641,12 +664,13 @@ typedef struct {
 
 /// @brief Motion event.
 typedef struct {
-	int32_t x;     ///< If `relative` is true, the horizontal delta since the previous motion
-	               ///<   event, otherwise the horizontal position in the window's client area.
-	int32_t y;     ///< In `relative` is true, the vertical delta since the previous motion event,
-	               ///<   otherwise the vertical position in the window's client area.
-	bool relative; ///< The event is a relative motion event.
-	bool synth;    ///< The event was synthesized by libmatoya.
+	MTY_MotionFlag flags; ///< Additional motion event flags.
+	int32_t x;            ///< If `relative` is true, the horizontal delta since the previous motion
+	                      ///<   event, otherwise the horizontal position in the window's client area.
+	int32_t y;            ///< In `relative` is true, the vertical delta since the previous motion event,
+	                      ///<   otherwise the vertical position in the window's client area.
+	bool relative;        ///< The event is a relative motion event.
+	bool synth;           ///< The event was synthesized by libmatoya.
 } MTY_MotionEvent;
 
 /// @brief File drop event.
@@ -698,6 +722,7 @@ typedef struct MTY_Event {
 		MTY_ControllerEvent controller; ///< Valid on MTY_EVENT_CONTROLLER, MTY_EVENT_CONNECT, and
 		                                ///<   MTY_EVENT_DISCONNECT.
 		MTY_ScrollEvent scroll;         ///< Valid on MTY_EVENT_SCROLL.
+		MTY_ScaleEvent scale;           ///< Valid on MTY_EVENT_SCALE.
 		MTY_ButtonEvent button;         ///< Valid on MTY_EVENT_BUTTON.
 		MTY_MotionEvent motion;         ///< Valid on MTY_EVENT_MOTION.
 		MTY_DropEvent drop;             ///< Valid on MTY_EVENT_DROP.

--- a/src/unix/linux/android/app.c
+++ b/src/unix/linux/android/app.c
@@ -41,6 +41,7 @@ static struct MTY_App {
 	bool check_scroller;
 	bool log_thread_running;
 	bool should_detach;
+	bool relative;
 
 	MTY_GFX api;
 	struct gfx_ctx *gfx_ctx;
@@ -324,17 +325,6 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1unhandled_1touch(JNIEnv
 
 	if (CTX.input != MTY_INPUT_MODE_TOUCHSCREEN) {
 		switch (action) {
-			case AMOTION_EVENT_ACTION_MOVE:
-				// While a long press is in effect, move events get reported here
-				// They do NOT come through in the onScroll gesture handler
-				if (CTX.long_button != MTY_BUTTON_NONE) {
-					MTY_Event evt = {0};
-					evt.type = MTY_EVENT_MOTION;
-					evt.motion.x = lrint(x);
-					evt.motion.y = lrint(y);
-					app_push_event(&CTX, &evt);
-				}
-				break;
 			case AMOTION_EVENT_ACTION_POINTER_DOWN:
 				// Taps with two fingers need to be handled manually
 				// They are not detected by the gesture recognizer
@@ -397,11 +387,10 @@ JNIEXPORT jboolean JNICALL Java_group_matoya_lib_Matoya_app_1long_1press(JNIEnv 
 }
 
 JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scroll(JNIEnv *env, jobject obj,
-	jfloat abs_x, jfloat abs_y, jfloat x, jfloat y, jint fingers)
+	jfloat abs_x, jfloat abs_y, jfloat x, jfloat y, jint fingers, jboolean start)
 {
 	CTX.should_detach = false;
-
-	app_cancel_long_button(&CTX, lrint(abs_x), lrint(abs_y));
+	CTX.double_tap = false;
 
 	// Single finger scrolling in touchscreen mode OR two finger scrolling in
 	// trackpad mode moves to the touch location and produces a scroll event
@@ -411,10 +400,14 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scroll(JNIEnv *env, job
 		MTY_Event evt = {0};
 
 		// Negative init values mean "don't move the cursor"
-		if (abs_x > 0.0f || abs_y > 0.0f) {
+		// Only move on the first event to prevent the cursor from going out of range
+		if (start && (abs_x > 0.0f || abs_y > 0.0f)) {
 			evt.type = MTY_EVENT_MOTION;
-			evt.motion.x = lrint(abs_x);
-			evt.motion.y = lrint(abs_y);
+			evt.motion.relative = CTX.relative;
+			evt.motion.x = CTX.relative ? -lrint(x) : lrint(abs_x);
+			evt.motion.y = CTX.relative ? -lrint(y) : lrint(abs_y);
+			evt.motion.flags |= MTY_MOTION_FLAG_TOUCH;
+			evt.motion.flags |= MTY_MOTION_FLAG_START;
 			app_push_event(&CTX, &evt);
 		}
 
@@ -428,8 +421,12 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scroll(JNIEnv *env, job
 	} else if (abs_x > 0.0f || abs_y > 0.0f) {
 		MTY_Event evt = {0};
 		evt.type = MTY_EVENT_MOTION;
-		evt.motion.x = lrint(abs_x);
-		evt.motion.y = lrint(abs_y);
+		evt.motion.relative = CTX.relative;
+		evt.motion.x = CTX.relative ? -lrint(x) : lrint(abs_x);
+		evt.motion.y = CTX.relative ? -lrint(y) : lrint(abs_y);
+		evt.motion.flags |= MTY_MOTION_FLAG_TOUCH;
+		if (start)
+			evt.motion.flags |= MTY_MOTION_FLAG_START;
 		app_push_event(&CTX, &evt);
 	}
 }
@@ -461,6 +458,24 @@ JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1generic_1scroll(JNIEnv 
 	evt.type = MTY_EVENT_SCROLL;
 	evt.scroll.x = x > 0.0f ? 120 : x < 0.0f ? -120 : 0;
 	evt.scroll.y = y > 0.0f ? 120 : y < 0.0f ? -120 : 0;
+	app_push_event(&CTX, &evt);
+}
+
+JNIEXPORT void JNICALL Java_group_matoya_lib_Matoya_app_1scale(JNIEnv *env, jobject obj,
+	jfloat scaleFactor, jfloat focus_x, jfloat focus_y, jboolean start, jboolean stop)
+{
+	CTX.should_detach = true;
+	CTX.double_tap = false;
+
+	MTY_Event evt = {0};
+	evt.type = MTY_EVENT_SCALE;
+	evt.scale.factor = scaleFactor;
+	evt.scale.focusX = focus_x;
+	evt.scale.focusY = focus_y;
+	evt.scale.state = 
+		start ? MTY_SCALE_STATE_START :
+		stop  ? MTY_SCALE_STATE_STOP  :
+		MTY_SCALE_STATE_ONGOING;
 	app_push_event(&CTX, &evt);
 }
 
@@ -804,12 +819,14 @@ void MTY_AppGrabMouse(MTY_App *ctx, bool grab)
 
 bool MTY_AppGetRelativeMouse(MTY_App *ctx)
 {
-	return mty_jni_bool(MTY_GetJNIEnv(), ctx->obj, "getRelativeMouse", "()Z");
+	return ctx->relative;
 }
 
 void MTY_AppSetRelativeMouse(MTY_App *ctx, bool relative)
 {
 	mty_jni_void(MTY_GetJNIEnv(), ctx->obj, "setRelativeMouse", "(Z)V", relative);
+
+	ctx->relative = relative;
 }
 
 void MTY_AppSetPNGCursor(MTY_App *ctx, const void *image, size_t size, uint32_t hotX, uint32_t hotY)
@@ -922,6 +939,11 @@ void MTY_AppSetInputMode(MTY_App *ctx, MTY_InputMode mode)
 
 MTY_Window MTY_WindowCreate(MTY_App *app, const MTY_WindowDesc *desc)
 {
+	if (desc->api != MTY_GFX_NONE && desc->api != MTY_GFX_GL)
+		return -1;
+	
+	MTY_WindowSetGFX(app, 0, desc->api, desc->vsync);
+
 	return 0;
 }
 


### PR DESCRIPTION
* `MTY_ScaleEvent`: This new event is sent when a scaling event is detected. It contains the focus position and the scaling factor relative to the previous scaling event. This event is currently only sent from the Android platform.
* `MTY_MotionFlag`: This flag exposes whether a motion event comes from a touch event, and if a motion gesture has just started. Those flags are currently only set when using the Android platform.