### PR TITLE
[Android] Ignore touch events when the view is obscured

### DIFF
--- a/src/unix/linux/android/Matoya.java
+++ b/src/unix/linux/android/Matoya.java
@@ -116,6 +116,7 @@ public class Matoya extends SurfaceView implements
 		this.getHolder().addCallback(this);
 		this.detector.setOnDoubleTapListener(this);
 		this.detector.setContextClickListener(this);
+		this.setFilterTouchesWhenObscured(true);
 		this.setFocusableInTouchMode(true);
 		this.setFocusable(true);
 		this.requestFocus();


### PR DESCRIPTION
Prevent touch events from being transmitted to the application when another application overlays it.