### PR TITLE
Better escaping methodology for WebView on macOS

### DIFF
--- a/src/unix/apple/webview.m
+++ b/src/unix/apple/webview.m
@@ -242,11 +242,15 @@ void mty_webview_send_text(struct webview *ctx, const char *msg)
 		MTY_QueuePushPtr(ctx->pushq, MTY_Strdup(msg), 0);
 
 	} else {
-		NSString *omsg = [NSString stringWithUTF8String:msg];
+		__block NSString *omsg = [NSString stringWithUTF8String:msg];
 		omsg = [omsg stringByReplacingOccurrencesOfString:@"'" withString:@"\\'"];
+		omsg = [omsg stringByReplacingOccurrencesOfString:@"\\" withString:@"\\\\"];
 		omsg = [NSString stringWithFormat:@"__MTY_WEBVIEW('%@');", omsg];
 
-		[ctx->webview evaluateJavaScript:omsg completionHandler:nil];
+		[ctx->webview evaluateJavaScript:omsg completionHandler:^(id obj, NSError *error) {
+			if (error)
+				NSLog(@"Error evaluating JS string %@ - %@", omsg, error);
+		}];
 	}
 }
 

--- a/src/unix/apple/webview.m
+++ b/src/unix/apple/webview.m
@@ -144,14 +144,14 @@ struct webview *mty_webview_create(MTY_App *app, MTY_Window window, const char *
 
 	// MTY javascript shim
 	WKUserScript *script = [[WKUserScript alloc] initWithSource:
-		@"let __MTY_WEBVIEW;"
+		@"let __MTY_WEBVIEW = b64 => {};"
 
 		@"function MTY_NativeSendText(text) {"
 			@"window.webkit.messageHandlers.native.postMessage('T' + text);"
 		@"}"
 
 		@"function MTY_NativeAddListener(func) {"
-			@"__MTY_WEBVIEW = func;"
+			@"__MTY_WEBVIEW = b64 => func(atob(b64));"
 			@"window.webkit.messageHandlers.native.postMessage('R');"
 		@"}"
 
@@ -242,14 +242,14 @@ void mty_webview_send_text(struct webview *ctx, const char *msg)
 		MTY_QueuePushPtr(ctx->pushq, MTY_Strdup(msg), 0);
 
 	} else {
-		const size_t sz = strlen(msg); // do NOT include the null-terminator
-		NSData *bytes = [NSData dataWithBytes:msg length:sz];
-		NSString *msg_base64 = [bytes base64EncodedStringWithOptions:0];
-		__block NSString *omsg = [NSString stringWithFormat:@"__MTY_WEBVIEW('%@');", msg_base64];
+		__block NSString *omsg = [NSString stringWithUTF8String:msg];
 
-		[ctx->webview evaluateJavaScript:omsg completionHandler:^(id obj, NSError *error) {
+		NSString *b64 = [[omsg dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:0];
+		NSString *wrapped = [NSString stringWithFormat:@"__MTY_WEBVIEW('%@');", b64];
+
+		[ctx->webview evaluateJavaScript:wrapped completionHandler:^(id object, NSError *error) {
 			if (error)
-				NSLog(@"Error evaluating JS string %@ - %@", omsg, error);
+				NSLog(@"'WKWebView:evaluateJavaScript' failed to evaluate string '%@'", omsg);
 		}];
 	}
 }

--- a/src/unix/apple/webview.m
+++ b/src/unix/apple/webview.m
@@ -242,10 +242,10 @@ void mty_webview_send_text(struct webview *ctx, const char *msg)
 		MTY_QueuePushPtr(ctx->pushq, MTY_Strdup(msg), 0);
 
 	} else {
-		__block NSString *omsg = [NSString stringWithUTF8String:msg];
-		omsg = [omsg stringByReplacingOccurrencesOfString:@"'" withString:@"\\'"];
-		omsg = [omsg stringByReplacingOccurrencesOfString:@"\\" withString:@"\\\\"];
-		omsg = [NSString stringWithFormat:@"__MTY_WEBVIEW('%@');", omsg];
+		const size_t sz = strlen(msg); // do NOT include the null-terminator
+		NSData *bytes = [NSData dataWithBytes:msg length:sz];
+		NSString *msg_base64 = [bytes base64EncodedStringWithOptions:0];
+		__block NSString *omsg = [NSString stringWithFormat:@"__MTY_WEBVIEW('%@');", msg_base64];
 
 		[ctx->webview evaluateJavaScript:omsg completionHandler:^(id obj, NSError *error) {
 			if (error)

--- a/src/windows/webview.c
+++ b/src/windows/webview.c
@@ -88,8 +88,6 @@ static HRESULT STDMETHODCALLTYPE h2_QueryInterface(void *This,
 	return E_NOINTERFACE;
 }
 
-static void mty_webview_post_message(struct webview *ctx, const char *msg);
-
 static HRESULT STDMETHODCALLTYPE h2_Invoke(ICoreWebView2WebMessageReceivedEventHandler *This,
 	ICoreWebView2 *sender, ICoreWebView2WebMessageReceivedEventArgs *args)
 {
@@ -109,9 +107,9 @@ static HRESULT STDMETHODCALLTYPE h2_Invoke(ICoreWebView2WebMessageReceivedEventH
 				ctx->ready = true;
 
 				// Send any queued messages before the WebView became ready
-				for (char *msg = NULL; MTY_QueuePopPtr(ctx->pushq, 0, &msg, NULL); /* */) {
-					mty_webview_post_message(ctx, msg);
-					MTY_Free(msg);
+				for (WCHAR *wmsg = NULL; MTY_QueuePopPtr(ctx->pushq, 0, &wmsg, NULL);) {
+					ICoreWebView2_PostWebMessageAsString(ctx->webview, wmsg);
+					MTY_Free(wmsg);
 				}
 
 				ctx->ready_func(ctx->app, ctx->window);
@@ -515,28 +513,15 @@ bool mty_webview_is_visible(struct webview *ctx)
 	return visible;
 }
 
-static void mty_webview_post_message(struct webview *ctx, const char *msg)
-{
-	const size_t sz_msg = strlen(msg); // do NOT include the null-terminating character in the base64 encoding
-	const size_t sz_msg_base64 = sz_msg * 2; // see here for math pertaining to buffer size estimation: https://stackoverflow.com/a/13378842
-
-	char *msg_base64 = MTY_Alloc(sz_msg_base64, 1);
-	MTY_BytesToBase64(msg, sz_msg, msg_base64, sz_msg_base64);
-
-	WCHAR *wmsg = MTY_MultiToWideD(msg_base64);
-	ICoreWebView2_PostWebMessageAsString(ctx->webview, wmsg);
-
-	MTY_Free(wmsg);
-	MTY_Free(msg_base64);
-}
-
 void mty_webview_send_text(struct webview *ctx, const char *msg)
 {
 	if (!ctx->ready) {
-		MTY_QueuePushPtr(ctx->pushq, MTY_Strdup(msg), 0);
+		MTY_QueuePushPtr(ctx->pushq, MTY_MultiToWideD(msg), 0);
 
 	} else {
-		mty_webview_post_message(ctx, msg);
+		WCHAR *wmsg = MTY_MultiToWideD(msg);
+		ICoreWebView2_PostWebMessageAsString(ctx->webview, wmsg);
+		MTY_Free(wmsg);
 	}
 }
 


### PR DESCRIPTION
> Currently, text messages containing serialized JSON are sent incorrectly to the WebView. This PR fixes this by escaping the escape character `'\'` on all such strings. I have tested that this works on strings ranging from simple strings to multiple layers of JSON serialized strings.

**Scratch the above**.

Message passing is now done as base64-encoded strings. This nicely avoids all character escaping woes. We will revisit this solution if the encoding/decoding overhead proves to be problematic.