### PR TITLE
Fix window number in macOS events

### DIFF
--- a/src/unix/apple/macosx/app.m
+++ b/src/unix/apple/macosx/app.m
@@ -553,7 +553,7 @@ static void window_pen_event(struct window *ctx, NSEvent *event, bool pressed)
 
 	MTY_Event evt = {
 		.type = MTY_EVENT_PEN,
-		.window = ctx->window,
+		.window = cur->window,
 		.pen.pressure = (uint16_t) lrint(event.pressure * 1024.0f),
 		.pen.rotation = (uint16_t) lrint(event.rotation * 359.0f),
 		.pen.tiltX = (int8_t) lrint(event.tilt.x * 90.0f),
@@ -604,7 +604,7 @@ static void window_mouse_button_event(struct window *ctx, NSUInteger index, bool
 
 	MTY_Event evt = {
 		.type = MTY_EVENT_BUTTON,
-		.window = ctx->window,
+		.window = cur->window,
 		.button.button = APP_MOUSE_MAP[index],
 		.button.pressed = pressed,
 		.button.x = lrint(scale * p.x),
@@ -704,7 +704,7 @@ static void window_mouse_motion_event(struct window *ctx, NSEvent *event, bool p
 
 				MTY_Event evt = {
 					.type = MTY_EVENT_MOTION,
-					.window = ctx->window,
+					.window = cur->window,
 					.motion.relative = false,
 					.motion.x = lrint(scale * p.x),
 					.motion.y = lrint(scale * p.y),


### PR DESCRIPTION
During #96 the wrong window gets passed during mouse movement.