### PR TITLE
Fix tests not compiling after HTTP interface change

### DIFF
--- a/test/src/1-draw.c
+++ b/test/src/1-draw.c
@@ -54,13 +54,12 @@ int main(int argc, char **argv)
 	MTY_WindowSetGFX(ctx.app, 0, MTY_GetDefaultGFX(), true);
 
 	// Fetch a PNG from the internet
+	const char *url = "https://snowcone.ltd/misc/ff.png";
 	void *png = NULL;
 	size_t png_size = 0;
 	uint16_t code = 0;
-	if (MTY_HttpRequest(
-		"https://user-images.githubusercontent.com/328897/112402607-36d00780-8ce3-11eb-9707-d11bc6c73c59.png",
-		"GET", NULL, NULL, 0, NULL, 5000, &png, &png_size, &code))
-	{
+
+	if (MTY_HttpRequest(url, "GET", NULL, NULL, 0, NULL, 5000, &png, &png_size, &code)) {
 		// On success, decompress it into RGBA
 		if (code == 200)
 			ctx.image = MTY_DecompressImage(png, png_size, &ctx.image_w, &ctx.image_h);

--- a/test/src/1-draw.c
+++ b/test/src/1-draw.c
@@ -57,9 +57,9 @@ int main(int argc, char **argv)
 	void *png = NULL;
 	size_t png_size = 0;
 	uint16_t code = 0;
-	if (MTY_HttpRequest("user-images.githubusercontent.com", 0, true, "GET",
-		"/328897/112402607-36d00780-8ce3-11eb-9707-d11bc6c73c59.png",
-		NULL, NULL, 0, 5000, &png, &png_size, &code))
+	if (MTY_HttpRequest(
+		"https://user-images.githubusercontent.com/328897/112402607-36d00780-8ce3-11eb-9707-d11bc6c73c59.png",
+		"GET", NULL, NULL, 0, NULL, 5000, &png, &png_size, &code))
 	{
 		// On success, decompress it into RGBA
 		if (code == 200)

--- a/test/src/2-threaded.c
+++ b/test/src/2-threaded.c
@@ -65,9 +65,9 @@ int main(int argc, char **argv)
 	void *png = NULL;
 	size_t png_size = 0;
 	uint16_t code = 0;
-	if (MTY_HttpRequest("user-images.githubusercontent.com", 0, true, "GET",
-		"/328897/112402607-36d00780-8ce3-11eb-9707-d11bc6c73c59.png",
-		NULL, NULL, 0, 5000, &png, &png_size, &code))
+	if (MTY_HttpRequest(
+		"https://user-images.githubusercontent.com/328897/112402607-36d00780-8ce3-11eb-9707-d11bc6c73c59.png",
+		"GET", NULL, NULL, 0, NULL, 5000, &png, &png_size, &code))
 	{
 		if (code == 200)
 			ctx.image = MTY_DecompressImage(png, png_size, &ctx.image_w, &ctx.image_h);

--- a/test/src/2-threaded.c
+++ b/test/src/2-threaded.c
@@ -62,13 +62,12 @@ int main(int argc, char **argv)
 
 	MTY_WindowCreate(ctx.app, "My Window", NULL, 0);
 
+	const char *url = "https://snowcone.ltd/misc/ff.png";
 	void *png = NULL;
 	size_t png_size = 0;
 	uint16_t code = 0;
-	if (MTY_HttpRequest(
-		"https://user-images.githubusercontent.com/328897/112402607-36d00780-8ce3-11eb-9707-d11bc6c73c59.png",
-		"GET", NULL, NULL, 0, NULL, 5000, &png, &png_size, &code))
-	{
+
+	if (MTY_HttpRequest(url, "GET", NULL, NULL, 0, NULL, 5000, &png, &png_size, &code)) {
 		if (code == 200)
 			ctx.image = MTY_DecompressImage(png, png_size, &ctx.image_w, &ctx.image_h);
 

--- a/test/src/test/net.h
+++ b/test/src/test/net.h
@@ -12,8 +12,8 @@
 static bool net_websocket_echo(void)
 {
 	uint16_t us = 0;
-	MTY_WebSocket *ws = MTY_WebSocketConnect("echo.websocket.events", 443, true, "/",
-		"Origin: https://echo.websocket.events", 10000, &us);
+	MTY_WebSocket *ws = MTY_WebSocketConnect("https://echo.websocket.events/",
+		"Origin: https://echo.websocket.events", NULL, 10000, &us);
 	test_cmp("MTY_WebSocketConnect", ws != NULL);
 	test_cmp("Upgrade Status", us == 101);
 
@@ -39,7 +39,7 @@ static bool net_websocket_echo(void)
 }
 
 #define badssl_test(host, should_fail) \
-	ok = MTY_HttpRequest(host, 0, true, "GET", "/", header_agent, NULL, 0, 10000, &resp, &resp_size, &resp_code); \
+	ok = MTY_HttpRequest("https://" host "/", "GET", header_agent, NULL, 0, NULL, 10000, &resp, &resp_size, &resp_code); \
 	MTY_Free(resp); \
 	test_print_cmps("MTY_HttpRequest", should_fail ? !ok : ok, ": " host); \
 	result = result && (should_fail ? !ok : ok);


### PR DESCRIPTION
I wanted to try the tests but the 1-draw and 2-threaded tests would not compile.

The change of HTTP interface had not been applied to the tests.