### PR TITLE
when there's a json parse error, line number and column are reported

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -347,10 +347,12 @@ MTY_JSON *MTY_JSONParse(const char *input)
 	char *key = NULL;
 
 	uint32_t p = 0;
+	int32_t line = 1, column = 1;
 
 	for (; p < len; p++) {
 		char c = input[p];
 
+		column -= p;		
 		switch (JSON_CHARS[(uint8_t) c]) {
 			case 1: {
 				MTY_JSON *j = c == '{' ? MTY_JSONObjCreate() : MTY_JSONArrayCreate(0);
@@ -423,12 +425,23 @@ MTY_JSON *MTY_JSONParse(const char *input)
 			default:
 				goto except;
 		}
+		column += p;
+
+		if (c == '\r') {
+			++line;
+			column = 1;
+		}
+		else {
+			++column;
+		}
 	}
+	column -= p;
 
 	except:
 
+	column += p;
 	if (key || nest != 0 || p != len) {
-		MTY_Log("Parse error at position %u", p);
+		MTY_Log("Parse error at line %d column %d", line, column);
 		MTY_JSONDestroy(&root);
 	}
 

--- a/src/json.c
+++ b/src/json.c
@@ -430,8 +430,7 @@ MTY_JSON *MTY_JSONParse(const char *input)
 		if (c == '\r') {
 			++line;
 			column = 1;
-		}
-		else {
+		} else {
 			++column;
 		}
 	}


### PR DESCRIPTION
this is better than reporting just the byte position in the JSON file, as text editors universally report line number and column

