### PR TITLE
Add support for the XBox Elite Series 2 pad

### DIFF
--- a/src/hid/hid.c
+++ b/src/hid/hid.c
@@ -51,6 +51,7 @@ MTY_CType hid_driver(struct hid_dev *device)
 		case 0x045E02FD: // Microsoft X-Box One S pad (Bluetooth)
 		case 0x045E0B05: // Microsoft X-Box One Elite Series 2 pad (Bluetooth)
 		case 0x045E0B13: // Microsoft X-Box Series X (Bluetooth)
+		case 0x045E0B22: // Microsoft X-Box Elite Series 2 pad (Bluetooth)
 			return MTY_CTYPE_XBOX;
 
 		// Xbox Wired

--- a/src/hid/xbox.h
+++ b/src/hid/xbox.h
@@ -69,7 +69,8 @@ static void xbox_do_rumble(struct hid_dev *device)
 static void xbox_init(struct hid_dev *device)
 {
 	struct xbox_state *ctx = mty_hid_device_get_state(device);
-	ctx->series_x = mty_hid_device_get_pid(device) == 0x0B13;
+	uint16_t device_pid = mty_hid_device_get_pid(device);
+	ctx->series_x = device_pid == 0x0B13 || device_pid == 0x0B22;
 	ctx->rumble = true;
 }
 


### PR DESCRIPTION
I'm not sure how my device is different from the XBox One Elite Series 2, but the identifiers are different and it's giving me a hard time with a downstream project. The name I gave it is the one on the packaging.