### PR TITLE
Check Keyboard Source before Gamepad Source for keyEvent handling

### DIFF
--- a/src/unix/linux/android/Matoya.java
+++ b/src/unix/linux/android/Matoya.java
@@ -194,6 +194,11 @@ public class Matoya extends SurfaceView implements
 
 	// Events
 
+	static boolean isKeyboardEvent(InputEvent event) {
+		return
+			(event.getSource() & InputDevice.SOURCE_KEYBOARD) == InputDevice.SOURCE_KEYBOARD;
+	}
+
 	static boolean isMouseEvent(InputEvent event) {
 		return
 			(event.getSource() & InputDevice.SOURCE_MOUSE) == InputDevice.SOURCE_MOUSE ||
@@ -208,6 +213,13 @@ public class Matoya extends SurfaceView implements
 	}
 
 	boolean keyEvent(int keyCode, KeyEvent event, boolean down) {
+		// For mixed source InputDevice, we prefer Keyboard event handling to Gamepad event handling
+		if (isKeyboardEvent(event)) {
+			int uc = event.getUnicodeChar();
+
+			return app_key(down, keyCode, uc != 0 ? String.format("%c", uc) : null,
+				event.getMetaState(), event.getDeviceId() <= 0);
+		}
 		// Button events fire here (sometimes dpad)
 		if (isGamepadEvent(event)) {
 			app_button(event.getDeviceId(), down, keyCode);


### PR DESCRIPTION
According to [InputDevice](https://developer.android.com/reference/android/view/InputDevice):

> A multi-function keyboard may compose the capabilities of a standard keyboard together with a track pad mouse or other pointing device 

When handling keyEvent from such device, between `SOURCE_KEYBOARD` and `[SOURCE_GAMEPAD, SOURCE_JOYSTICK, SOURCE_DPAD]`, it might be better to prefer `SOURCE_KEYBOARD` handling. 

There is a downstream issue in Parsec, on Samsung Galaxy Tab S8/S9 with Book Cover Keyboard, the keyEvents from this keyboard have both `SOURCE_KEYBOARD` and `SOURCE_DPAD` sources. But since the existing code handles these keyEvents as Gamepad event, normal keyboard presses don't do anything. 

This change adds a `SOURCE_KEYBOARD` check before the Gamepad check so that Keyboard handling is preferred over Gamepad handling in multi source devices. 